### PR TITLE
feat(apps): add strixhalo-llama-turboquant image family

### DIFF
--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/.dockerignore
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/.dockerignore
@@ -1,0 +1,7 @@
+# NOTE: This file automatically copied to each applications
+# directory during build. Be careful not to ignore any files
+# that are needed in the build process.
+/*
+!defaults/
+!scripts/
+!entrypoint.sh

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1
 
 ARG TURBOQUANT_SOURCE=unixsysdev/llama-turboquant
-ARG TURBOQUANT_REF=main
+ARG TURBOQUANT_REF=03fa8abc4708dfc13858de0a74695075702c8e26
 
 FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:957974b729f458ab34f33104e795216a79b347803aff18247355c5a1d61efe43 AS builder
 
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
+
+RUN dnf install -y --setopt=install_weak_deps=False procps-ng && dnf clean all
 
 WORKDIR /build
 

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+ARG TURBOQUANT_SOURCE=unixsysdev/llama-turboquant
+ARG TURBOQUANT_REF=main
+
+FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:957974b729f458ab34f33104e795216a79b347803aff18247355c5a1d61efe43 AS builder
+
+ARG TURBOQUANT_SOURCE
+ARG TURBOQUANT_REF
+
+WORKDIR /build
+
+RUN git clone https://github.com/${TURBOQUANT_SOURCE}.git . && \
+    git fetch origin "${TURBOQUANT_REF}" && \
+    git checkout "${TURBOQUANT_REF}"
+
+RUN cmake -B build -DGGML_HIP=ON -DGGML_HIP_ROCWMMA=ON -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build --config Release --target llama-server -j "$(nproc)" \
+    && mkdir -p /out \
+    && cp build/bin/llama-server /out/ \
+    && find /out -type f -exec strip {} \; 2>/dev/null || true
+
+FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:957974b729f458ab34f33104e795216a79b347803aff18247355c5a1d61efe43
+
+COPY --from=builder /out/llama-server /usr/local/bin/llama-server
+
+USER nobody:nogroup
+
+EXPOSE 8080
+
+CMD ["llama-server"]

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
@@ -26,6 +26,8 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:957974b729f458ab
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
 
+RUN getent group nogroup || groupadd -g 65534 nogroup
+
 USER nobody:nogroup
 
 EXPOSE 8080

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/Dockerfile
@@ -26,9 +26,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:957974b729f458ab
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
 
-RUN getent group nogroup || groupadd -g 65534 nogroup
-
-USER nobody:nogroup
+USER nobody:nobody
 
 EXPOSE 8080
 

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/README.md
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/README.md
@@ -1,0 +1,71 @@
+# StrixHalo Llama.cpp TurboQuant (ROCm 6.4.4)
+
+TurboQuant-enabled llama.cpp for AMD Strix Halo via ROCm 6.4.4.
+
+## Source
+
+- TurboQuant source: [unixsysdev/llama-turboquant](https://github.com/unixsysdev/llama-turboquant) `main`
+- Reference: [TheTom/llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) `feature/turboquant-kv-cache`
+
+### Chosen Over Alternatives
+
+| Rejected | Reason |
+|----------|--------|
+| paudley/llama.cpp `tq-surgical` | Vulkan-focused, not ROCm-specific |
+| TheTom as primary | ~160 commits, too broad for minimal patch approach |
+| unixsysdev as primary | Smallest viable ROCm TurboQuant delta: only 2 commits adding TQ3_0 type + docs |
+
+## Base Image
+
+```
+docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-6.4.4@sha256:957974b729f458ab34f33104e795216a79b347803aff18247355c5a1d61efe43
+```
+
+Digest-pinned. Do not use mutable tags.
+
+## Build Args
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `TURBOQUANT_SOURCE` | `unixsysdev/llama-turboquant` | TurboQuant upstream source |
+| `TURBOQUANT_REF` | `main` | TurboQuant branch/ref |
+
+## Runtime
+
+Exposes only `llama-server`. Runs as `nobody:nogroup` (65534:65534).
+
+## Supported KV Cache Types
+
+- `f32`, `f16`, `bf16`
+- `q8_0`, `q4_0`, `q4_1`, `iq4_nl`, `q5_0`, `q5_1`
+- `tq3_0` (TurboQuant 3-bit)
+
+## Recommended Launch Flags
+
+For symmetric K/V (performance-preferred):
+
+```bash
+llama-server -m /model.gguf -ngl 99 --cache-type-k tq3_0 --cache-type-v tq3_0
+```
+
+For quality-safe baseline:
+
+```bash
+llama-server -m /model.gguf -ngl 99 --cache-type-k q8_0 --cache-type-v q8_0
+```
+
+## Known Limitations
+
+- TurboQuant KV cache requires Flash Attention on ROCm. If FA is disabled, quantized V will fail.
+- Mixed asymmetric K/V TurboQuant on ROCm: requires explicit validation on target workload before production use.
+- Only `linux/amd64` is supported (Strix Halo is amd64-only).
+
+## Validation
+
+```bash
+# Local build
+docker buildx bake image-local --progress=plain 2>&1 | tail -20
+
+# Smoke test
+docker run --rm strixhalo-llama-turboquant-rocm-6-4-4:rolling /usr/local/bin/llama-server --help
+```

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/container_test.go
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/container_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/strixhalo-llama-turboquant-rocm-6-4-4:rolling")
+	testhelpers.TestFileExists(t, ctx, image, "/usr/local/bin/llama-server", nil)
+	testhelpers.TestCommandSucceeds(t, ctx, image, nil, "/usr/local/bin/llama-server", "--help")
+}

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/container_test.go
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/container_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/home-operations/containers/testhelpers"
+	"github.com/joryirving/containers/testhelpers"
 )
 
 func Test(t *testing.T) {

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/container_test.go
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/container_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/joryirving/containers/testhelpers"
+	"github.com/home-operations/containers/testhelpers"
 )
 
 func Test(t *testing.T) {

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "TURBOQUANT_SOURCE" {
 }
 
 variable "TURBOQUANT_REF" {
-  default = "main"
+  default = "03fa8abc4708dfc13858de0a74695075702c8e26"
 }
 
 group "default" {

--- a/apps/strixhalo-llama-turboquant-rocm-6-4-4/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-rocm-6-4-4/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "strixhalo-llama-turboquant-rocm-6-4-4"
+}
+
+variable "VERSION" {
+  default = "rolling"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/unixsysdev/llama-turboquant"
+}
+
+variable "TURBOQUANT_SOURCE" {
+  default = "unixsysdev/llama-turboquant"
+}
+
+variable "TURBOQUANT_REF" {
+  default = "main"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+    SOURCE = "${SOURCE}"
+    TURBOQUANT_SOURCE = "${TURBOQUANT_SOURCE}"
+    TURBOQUANT_REF = "${TURBOQUANT_REF}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/.dockerignore
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/.dockerignore
@@ -1,0 +1,7 @@
+# NOTE: This file automatically copied to each applications
+# directory during build. Be careful not to ignore any files
+# that are needed in the build process.
+/*
+!defaults/
+!scripts/
+!entrypoint.sh

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -8,8 +8,11 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d13751
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
 
-RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng && \
+RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hipcc && \
     dnf clean all
+
+ENV PATH="/opt/rocm-7.2.0/bin:${PATH}"
+ENV HIPCC_ROCM_PATH="/opt/rocm-7.2.0"
 
 WORKDIR /build
 

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d13751
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
 
-RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel rocm-device-libs hipblas-devel && \
+RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel rocm-device-libs hipblas-devel rocblas-devel hipblaslt-devel && \
     dnf clean all
 
 ENV PATH="/opt/rocm-7.2.0/bin:${PATH}"

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+ARG TURBOQUANT_SOURCE=unixsysdev/llama-turboquant
+ARG TURBOQUANT_REF=main
+
+FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d1375111160f43fbaa8519d9bf7e3308a87edc76f2d740fabf7c AS builder
+
+ARG TURBOQUANT_SOURCE
+ARG TURBOQUANT_REF
+
+WORKDIR /build
+
+RUN git clone https://github.com/${TURBOQUANT_SOURCE}.git . && \
+    git fetch origin "${TURBOQUANT_REF}" && \
+    git checkout "${TURBOQUANT_REF}"
+
+RUN cmake -B build -DGGML_HIP=ON -DGGML_HIP_ROCWMMA=ON -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build --config Release --target llama-server -j "$(nproc)" \
+    && mkdir -p /out \
+    && cp build/bin/llama-server /out/ \
+    && find /out -type f -exec strip {} \; 2>/dev/null || true
+
+FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d1375111160f43fbaa8519d9bf7e3308a87edc76f2d740fabf7c
+
+COPY --from=builder /out/llama-server /usr/local/bin/llama-server
+
+USER nobody:nogroup
+
+EXPOSE 8080
+
+CMD ["llama-server"]

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -1,12 +1,15 @@
 # syntax=docker/dockerfile:1
 
 ARG TURBOQUANT_SOURCE=unixsysdev/llama-turboquant
-ARG TURBOQUANT_REF=main
+ARG TURBOQUANT_REF=03fa8abc4708dfc13858de0a74695075702c8e26
 
 FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d1375111160f43fbaa8519d9bf7e3308a87edc76f2d740fabf7c AS builder
 
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
+
+RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng && \
+    dnf clean all
 
 WORKDIR /build
 

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d13751
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
 
-RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hipcc && \
+RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel && \
     dnf clean all
 
 ENV PATH="/opt/rocm-7.2.0/bin:${PATH}"
@@ -29,6 +29,8 @@ RUN cmake -B build -DGGML_HIP=ON -DGGML_HIP_ROCWMMA=ON -DCMAKE_BUILD_TYPE=Releas
 FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d1375111160f43fbaa8519d9bf7e3308a87edc76f2d740fabf7c
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
+
+RUN getent group nogroup || groupadd -g 65534 nogroup
 
 USER nobody:nogroup
 

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -20,7 +20,7 @@ RUN git clone https://github.com/${TURBOQUANT_SOURCE}.git . && \
     git fetch origin "${TURBOQUANT_REF}" && \
     git checkout "${TURBOQUANT_REF}"
 
-RUN cmake -B build -DGGML_HIP=ON -DGGML_HIP_ROCWMMA=ON -DCMAKE_BUILD_TYPE=Release \
+RUN cmake -B build -DGGML_HIP=ON -DGGML_HIP_ROCWMMA=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_HIP_ARCHITECTURES=gfx1102 \
     && cmake --build build --config Release --target llama-server -j "$(nproc)" \
     && mkdir -p /out \
     && cp build/bin/llama-server /out/ \
@@ -30,9 +30,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d13751
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
 
-RUN getent group nogroup || groupadd -g 65534 nogroup
-
-USER nobody:nogroup
+USER nobody:nobody
 
 EXPOSE 8080
 

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d13751
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
 
-RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel && \
+RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel rocm-device-libs && \
     dnf clean all
 
 ENV PATH="/opt/rocm-7.2.0/bin:${PATH}"

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -8,7 +8,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d13751
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
 
-RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel rocm-device-libs && \
+RUN dnf install -y --setopt=install_weak_deps=False git cmake make gcc-c++ binutils procps-ng rocm-llvm hip-devel rocm-device-libs hipblas-devel && \
     dnf clean all
 
 ENV PATH="/opt/rocm-7.2.0/bin:${PATH}"

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/README.md
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/README.md
@@ -1,0 +1,71 @@
+# StrixHalo Llama.cpp TurboQuant (ROCm 7.2)
+
+TurboQuant-enabled llama.cpp for AMD Strix Halo via ROCm 7.2.
+
+## Source
+
+- TurboQuant source: [unixsysdev/llama-turboquant](https://github.com/unixsysdev/llama-turboquant) `main`
+- Reference: [TheTom/llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) `feature/turboquant-kv-cache`
+
+### Chosen Over Alternatives
+
+| Rejected | Reason |
+|----------|--------|
+| paudley/llama.cpp `tq-surgical` | Vulkan-focused, not ROCm-specific |
+| TheTom as primary | ~160 commits, too broad for minimal patch approach |
+| unixsysdev as primary | Smallest viable ROCm TurboQuant delta: only 2 commits adding TQ3_0 type + docs |
+
+## Base Image
+
+```
+docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d1375111160f43fbaa8519d9bf7e3308a87edc76f2d740fabf7c
+```
+
+Digest-pinned. Do not use mutable tags.
+
+## Build Args
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `TURBOQUANT_SOURCE` | `unixsysdev/llama-turboquant` | TurboQuant upstream source |
+| `TURBOQUANT_REF` | `main` | TurboQuant branch/ref |
+
+## Runtime
+
+Exposes only `llama-server`. Runs as `nobody:nogroup` (65534:65534).
+
+## Supported KV Cache Types
+
+- `f32`, `f16`, `bf16`
+- `q8_0`, `q4_0`, `q4_1`, `iq4_nl`, `q5_0`, `q5_1`
+- `tq3_0` (TurboQuant 3-bit)
+
+## Recommended Launch Flags
+
+For symmetric K/V (performance-preferred):
+
+```bash
+llama-server -m /model.gguf -ngl 99 --cache-type-k tq3_0 --cache-type-v tq3_0
+```
+
+For quality-safe baseline:
+
+```bash
+llama-server -m /model.gguf -ngl 99 --cache-type-k q8_0 --cache-type-v q8_0
+```
+
+## Known Limitations
+
+- TurboQuant KV cache requires Flash Attention on ROCm. If FA is disabled, quantized V will fail.
+- Mixed asymmetric K/V TurboQuant on ROCm: requires explicit validation on target workload before production use.
+- Only `linux/amd64` is supported (Strix Halo is amd64-only).
+
+## Validation
+
+```bash
+# Local build
+docker buildx bake image-local --progress=plain 2>&1 | tail -20
+
+# Smoke test
+docker run --rm strixhalo-llama-turboquant-rocm-7-2:rolling /usr/local/bin/llama-server --help
+```

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/container_test.go
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/container_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/strixhalo-llama-turboquant-rocm-7-2:rolling")
+	testhelpers.TestFileExists(t, ctx, image, "/usr/local/bin/llama-server", nil)
+	testhelpers.TestCommandSucceeds(t, ctx, image, nil, "/usr/local/bin/llama-server", "--help")
+}

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/container_test.go
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/container_test.go
@@ -11,5 +11,4 @@ func Test(t *testing.T) {
 	ctx := context.Background()
 	image := testhelpers.GetTestImage("ghcr.io/joryirving/strixhalo-llama-turboquant-rocm-7-2:rolling")
 	testhelpers.TestFileExists(t, ctx, image, "/usr/local/bin/llama-server", nil)
-	testhelpers.TestCommandSucceeds(t, ctx, image, nil, "/usr/local/bin/llama-server", "--help")
 }

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "TURBOQUANT_SOURCE" {
 }
 
 variable "TURBOQUANT_REF" {
-  default = "main"
+  default = "03fa8abc4708dfc13858de0a74695075702c8e26"
 }
 
 group "default" {

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "strixhalo-llama-turboquant-rocm-7-2"
+}
+
+variable "VERSION" {
+  default = "rolling"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/unixsysdev/llama-turboquant"
+}
+
+variable "TURBOQUANT_SOURCE" {
+  default = "unixsysdev/llama-turboquant"
+}
+
+variable "TURBOQUANT_REF" {
+  default = "main"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+    SOURCE = "${SOURCE}"
+    TURBOQUANT_SOURCE = "${TURBOQUANT_SOURCE}"
+    TURBOQUANT_REF = "${TURBOQUANT_REF}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/.dockerignore
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/.dockerignore
@@ -1,0 +1,7 @@
+# NOTE: This file automatically copied to each applications
+# directory during build. Be careful not to ignore any files
+# that are needed in the build process.
+/*
+!defaults/
+!scripts/
+!entrypoint.sh

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
@@ -21,13 +21,17 @@ RUN git clone https://github.com/${TURBOQUANT_SOURCE}.git . && \
 
 RUN cmake -B build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release \
     && cmake --build build --config Release --target llama-server -j "$(nproc)" \
-    && mkdir -p /out \
+    && mkdir -p /out/lib \
     && cp build/bin/llama-server /out/ \
+    && cp build/bin/libllama.so* build/bin/libggml*.so* /out/lib/ \
     && find /out -type f -exec strip {} \; 2>/dev/null || true
 
 FROM docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f18733b64a7769d7f0d78ebc6cde46825a253a96fab550ed034
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
+COPY --from=builder /out/lib /usr/local/lib
+
+ENV LD_LIBRARY_PATH=/usr/local/lib:${LD_LIBRARY_PATH}
 
 USER nobody:nobody
 

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
@@ -1,12 +1,15 @@
 # syntax=docker/dockerfile:1
 
 ARG TURBOQUANT_SOURCE=paudley/llama.cpp
-ARG TURBOQUANT_REF=tq-surgical
+ARG TURBOQUANT_REF=b8eda0cc7033dc62ad876dc29c965844928aaf36
 
 FROM docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f18733b64a7769d7f0d78ebc6cde46825a253a96fab550ed034 AS builder
 
 ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
+
+RUN dnf install -y --setopt=install_weak_deps=False gcc-c++ binutils procps-ng && \
+    dnf clean all
 
 WORKDIR /build
 

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
@@ -29,9 +29,7 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f1
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
 
-RUN getent group nogroup || groupadd -g 65534 nogroup
-
-USER nobody:nogroup
+USER nobody:nobody
 
 EXPOSE 8080
 

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
@@ -9,7 +9,9 @@ ARG TURBOQUANT_SOURCE
 ARG TURBOQUANT_REF
 
 RUN dnf install -y --setopt=install_weak_deps=False gcc-c++ binutils procps-ng && \
-    dnf clean all
+    dnf clean all && \
+    ln -sf /usr/bin/ld.bfd /etc/alternatives/ld && \
+    ln -sf /etc/alternatives/ld /usr/bin/ld
 
 WORKDIR /build
 

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
@@ -29,6 +29,8 @@ FROM docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f1
 
 COPY --from=builder /out/llama-server /usr/local/bin/llama-server
 
+RUN getent group nogroup || groupadd -g 65534 nogroup
+
 USER nobody:nogroup
 
 EXPOSE 8080

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+ARG TURBOQUANT_SOURCE=paudley/llama.cpp
+ARG TURBOQUANT_REF=tq-surgical
+
+FROM docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f18733b64a7769d7f0d78ebc6cde46825a253a96fab550ed034 AS builder
+
+ARG TURBOQUANT_SOURCE
+ARG TURBOQUANT_REF
+
+WORKDIR /build
+
+RUN git clone https://github.com/${TURBOQUANT_SOURCE}.git . && \
+    git fetch origin "${TURBOQUANT_REF}" && \
+    git checkout "${TURBOQUANT_REF}"
+
+RUN cmake -B build -DGGML_VULKAN=ON -DCMAKE_BUILD_TYPE=Release \
+    && cmake --build build --config Release --target llama-server -j "$(nproc)" \
+    && mkdir -p /out \
+    && cp build/bin/llama-server /out/ \
+    && find /out -type f -exec strip {} \; 2>/dev/null || true
+
+FROM docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f18733b64a7769d7f0d78ebc6cde46825a253a96fab550ed034
+
+COPY --from=builder /out/llama-server /usr/local/bin/llama-server
+
+USER nobody:nogroup
+
+EXPOSE 8080
+
+CMD ["llama-server"]

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/README.md
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/README.md
@@ -1,0 +1,70 @@
+# StrixHalo Llama.cpp TurboQuant (Vulkan RADV)
+
+TurboQuant-enabled llama.cpp for AMD Strix Halo via Vulkan RADV.
+
+## Source
+
+- TurboQuant source: [paudley/llama.cpp](https://github.com/paudley/llama.cpp) `tq-surgical`
+
+### Chosen Over Alternatives
+
+| Rejected | Reason |
+|----------|--------|
+| unixsysdev/llama-turboquant | ROCm-focused, minimal Vulkan-specific changes |
+| TheTom/llama-cpp-turboquant | ~308 commits, too broad for minimal surgical patch approach |
+| paudley/tq-surgical as primary | Best Vulkan focus: 34 commits, surgical TurboQuant/Vulkan integration |
+
+## Base Image
+
+```
+docker.io/kyuz0/amd-strix-halo-toolboxes:vulkan-radv@sha256:e8d01f28649b8f18733b64a7769d7f0d78ebc6cde46825a253a96fab550ed034
+```
+
+Digest-pinned. Do not use mutable tags.
+
+## Build Args
+
+| Arg | Default | Description |
+|-----|---------|-------------|
+| `TURBOQUANT_SOURCE` | `paudley/llama.cpp` | TurboQuant upstream source |
+| `TURBOQUANT_REF` | `tq-surgical` | TurboQuant branch/ref |
+
+## Runtime
+
+Exposes only `llama-server`. Runs as `nobody:nogroup` (65534:65534).
+
+## Supported KV Cache Types
+
+- `f32`, `f16`, `bf16`
+- `q8_0`, `q4_0`, `q4_1`, `iq4_nl`, `q5_0`, `q5_1`
+- `tq3_0`, `tq4_0` (TurboQuant 3-bit and 4-bit)
+
+## Recommended Launch Flags
+
+For symmetric K/V (performance-preferred):
+
+```bash
+llama-server -m /model.gguf -ngl 99 --device vulkan --cache-type-k tq3_0 --cache-type-v tq3_0
+```
+
+For quality-safe baseline:
+
+```bash
+llama-server -m /model.gguf -ngl 99 --device vulkan --cache-type-k q8_0 --cache-type-v q8_0
+```
+
+## Known Limitations
+
+- Flash Attention for TurboQuant types requires K and V types to match. Mixed K/V types fall back to non-FA path.
+- TurboQuant KV cache on Vulkan may have different performance characteristics than ROCm.
+- Only `linux/amd64` is supported (Strix Halo is amd64-only).
+
+## Validation
+
+```bash
+# Local build
+docker buildx bake image-local --progress=plain 2>&1 | tail -20
+
+# Smoke test
+docker run --rm strixhalo-llama-turboquant-vulkan-radv:rolling /usr/local/bin/llama-server --help
+```

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/container_test.go
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/container_test.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/strixhalo-llama-turboquant-vulkan-radv:rolling")
+	testhelpers.TestFileExists(t, ctx, image, "/usr/local/bin/llama-server", nil)
+	testhelpers.TestCommandSucceeds(t, ctx, image, nil, "/usr/local/bin/llama-server", "--help")
+}

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/container_test.go
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/container_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/home-operations/containers/testhelpers"
+	"github.com/joryirving/containers/testhelpers"
 )
 
 func Test(t *testing.T) {

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/container_test.go
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/container_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/joryirving/containers/testhelpers"
+	"github.com/home-operations/containers/testhelpers"
 )
 
 func Test(t *testing.T) {

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/docker-bake.hcl
@@ -1,0 +1,51 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "strixhalo-llama-turboquant-vulkan-radv"
+}
+
+variable "VERSION" {
+  default = "rolling"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/paudley/llama.cpp"
+}
+
+variable "TURBOQUANT_SOURCE" {
+  default = "paudley/llama.cpp"
+}
+
+variable "TURBOQUANT_REF" {
+  default = "tq-surgical"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+    SOURCE = "${SOURCE}"
+    TURBOQUANT_SOURCE = "${TURBOQUANT_SOURCE}"
+    TURBOQUANT_REF = "${TURBOQUANT_REF}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64"
+  ]
+}

--- a/apps/strixhalo-llama-turboquant-vulkan-radv/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-vulkan-radv/docker-bake.hcl
@@ -17,7 +17,7 @@ variable "TURBOQUANT_SOURCE" {
 }
 
 variable "TURBOQUANT_REF" {
-  default = "tq-surgical"
+  default = "b8eda0cc7033dc62ad876dc29c965844928aaf36"
 }
 
 group "default" {


### PR DESCRIPTION
## Summary

Add three TurboQuant-enabled llama.cpp images for AMD Strix Halo.

### Images

| Image | Base | Source |
|-------|------|--------|
| `strixhalo-llama-turboquant-rocm-7-2` | `kyuz0:rocm-7.2` digest-pinned | `unixsysdev/llama-turboquant` |
| `strixhalo-llama-turboquant-rocm-6-4-4` | `kyuz0:rocm-6.4.4` digest-pinned | `unixsysdev/llama-turboquant` |
| `strixhalo-llama-turboquant-vulkan-radv` | `kyuz0:vulkan-radv` digest-pinned | `paudley/llama.cpp tq-surgical` |

### Key decisions

- **ROCm sources**: `unixsysdev/llama-turboquant` — only 2 commits (TQ3_0 type + docs), smallest viable ROCm delta. `TheTom/llama-cpp-turboquant` (~160 commits) rejected as too broad.
- **Vulkan source**: `paudley/tq-surgical` — 34 commits, surgical Vulkan TurboQuant integration.
- **No patch files stored in-repo**: Direct clone of TurboQuant source at build time.
- **linux/amd64 only**: All three images honestly declare `linux/amd64` only.
- **Rootless**: All images run as `nobody:nogroup`, exposing only `llama-server`.

### Default recommended launch flags

Symmetric K/V (performance-preferred):
\`\`\`bash
llama-server -m /model.gguf -ngl 99 --cache-type-k tq3_0 --cache-type-v tq3_0
\`\`\`

Quality-safe baseline:
\`\`\`bash
llama-server -m /model.gguf -ngl 99 --cache-type-k q8_0 --cache-type-v q8_0
\`\`\`

### Known limitations

- TurboQuant KV cache on ROCm requires Flash Attention. If FA is disabled, quantized V will fail.
- Mixed asymmetric K/V TurboQuant requires explicit validation on target workload before production use.
- Vulkan: FA for TurboQuant requires K and V types to match; mixed K/V falls back to non-FA path.