### PR TITLE
fix(rocm-7.2): retarget to TheTom/llama-cpp-turboquant for turbo4 support

### DIFF
--- a/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
-ARG TURBOQUANT_SOURCE=unixsysdev/llama-turboquant
-ARG TURBOQUANT_REF=03fa8abc4708dfc13858de0a74695075702c8e26
+ARG TURBOQUANT_SOURCE=TheTom/llama-cpp-turboquant
+ARG TURBOQUANT_REF=8ba9f128822b4cef73f5555ca5fcccfbfadbcd20
 
 FROM docker.io/kyuz0/amd-strix-halo-toolboxes:rocm-7.2@sha256:c246a5557e42d1375111160f43fbaa8519d9bf7e3308a87edc76f2d740fabf7c AS builder
 

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/README.md
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/README.md
@@ -4,16 +4,10 @@ TurboQuant-enabled llama.cpp for AMD Strix Halo via ROCm 7.2.
 
 ## Source
 
-- TurboQuant source: [unixsysdev/llama-turboquant](https://github.com/unixsysdev/llama-turboquant) `main`
-- Reference: [TheTom/llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) `feature/turboquant-kv-cache`
+- TurboQuant source: [TheTom/llama-cpp-turboquant](https://github.com/TheTom/llama-cpp-turboquant) `feature/turboquant-kv-cache`
+- Pinned commit: `8ba9f128822b4cef73f5555ca5fcccfbfadbcd20`
 
-### Chosen Over Alternatives
-
-| Rejected | Reason |
-|----------|--------|
-| paudley/llama.cpp `tq-surgical` | Vulkan-focused, not ROCm-specific |
-| TheTom as primary | ~160 commits, too broad for minimal patch approach |
-| unixsysdev as primary | Smallest viable ROCm TurboQuant delta: only 2 commits adding TQ3_0 type + docs |
+This fork explicitly supports HIP/AMD and exposes `turbo3` and `turbo4` KV cache types.
 
 ## Base Image
 
@@ -27,28 +21,29 @@ Digest-pinned. Do not use mutable tags.
 
 | Arg | Default | Description |
 |-----|---------|-------------|
-| `TURBOQUANT_SOURCE` | `unixsysdev/llama-turboquant` | TurboQuant upstream source |
-| `TURBOQUANT_REF` | `main` | TurboQuant branch/ref |
+| `TURBOQUANT_SOURCE` | `TheTom/llama-cpp-turboquant` | TurboQuant upstream source |
+| `TURBOQUANT_REF` | `8ba9f128822b4cef73f5555ca5fcccfbfadbcd20` | TurboQuant commit |
 
 ## Runtime
 
-Exposes only `llama-server`. Runs as `nobody:nogroup` (65534:65534).
+Exposes only `llama-server`. Runs as `nobody:nobody`.
 
 ## Supported KV Cache Types
 
 - `f32`, `f16`, `bf16`
 - `q8_0`, `q4_0`, `q4_1`, `iq4_nl`, `q5_0`, `q5_1`
-- `tq3_0` (TurboQuant 3-bit)
+- `turbo3` (TurboQuant 3-bit)
+- `turbo4` (TurboQuant 4-bit, recommended)
 
 ## Recommended Launch Flags
 
-For symmetric K/V (performance-preferred):
+Performance-preferred (turbo4 symmetric K/V):
 
 ```bash
-llama-server -m /model.gguf -ngl 99 --cache-type-k tq3_0 --cache-type-v tq3_0
+llama-server -m /model.gguf -ngl 99 --cache-type-k turbo4 --cache-type-v turbo4
 ```
 
-For quality-safe baseline:
+Quality-safe baseline:
 
 ```bash
 llama-server -m /model.gguf -ngl 99 --cache-type-k q8_0 --cache-type-v q8_0
@@ -57,7 +52,6 @@ llama-server -m /model.gguf -ngl 99 --cache-type-k q8_0 --cache-type-v q8_0
 ## Known Limitations
 
 - TurboQuant KV cache requires Flash Attention on ROCm. If FA is disabled, quantized V will fail.
-- Mixed asymmetric K/V TurboQuant on ROCm: requires explicit validation on target workload before production use.
 - Only `linux/amd64` is supported (Strix Halo is amd64-only).
 
 ## Validation

--- a/apps/strixhalo-llama-turboquant-rocm-7-2/docker-bake.hcl
+++ b/apps/strixhalo-llama-turboquant-rocm-7-2/docker-bake.hcl
@@ -9,15 +9,15 @@ variable "VERSION" {
 }
 
 variable "SOURCE" {
-  default = "https://github.com/unixsysdev/llama-turboquant"
+  default = "https://github.com/TheTom/llama-cpp-turboquant"
 }
 
 variable "TURBOQUANT_SOURCE" {
-  default = "unixsysdev/llama-turboquant"
+  default = "TheTom/llama-cpp-turboquant"
 }
 
 variable "TURBOQUANT_REF" {
-  default = "03fa8abc4708dfc13858de0a74695075702c8e26"
+  default = "8ba9f128822b4cef73f5555ca5fcccfbfadbcd20"
 }
 
 group "default" {


### PR DESCRIPTION
## Summary

- Replace `unixsysdev/llama-turboquant` with `TheTom/llama-cpp-turboquant` on `feature/turboquant-kv-cache`
- The previous fork only exposed `tq3_0`, which was the wrong TurboQuant lineage for ROCm
- TheTom's fork explicitly supports HIP/AMD and exposes `turbo3` and `turbo4` KV cache types
- Runtime target: `--cache-type-k turbo4 --cache-type-v turbo4`

## Changes

- `Dockerfile`: swap `TURBOQUANT_SOURCE` and pinned `TURBOQUANT_REF` to TheTom at `8ba9f128`
- `docker-bake.hcl`: update `SOURCE`, `TURBOQUANT_SOURCE`, `TURBOQUANT_REF` vars
- `README.md`: rewrite to document `turbo4` as the recommended KV mode, `turbo3` as secondary

## Verification

CI will confirm:
1. Image builds
2. `llama-server --help` exposes `turbo4`

## Next steps (follow-up PRs)

- Port same lineage to `rocm-6-4-4`
- Leave `vulkan-radv` on current lineage