### PR TITLE
feat(hoymiles-mqtt): add rootless container image

### DIFF
--- a/apps/hoymiles-mqtt/Dockerfile
+++ b/apps/hoymiles-mqtt/Dockerfile
@@ -1,0 +1,26 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/python:3.13-alpine3.23@sha256:420cd0bf0f3998275875e02ecd5808168cf0843cbb4d3c536432f729247b2acc
+ARG TARGETARCH
+ARG VERSION
+
+ENV \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PIP_NO_CACHE_DIR=1 \
+    PIP_ROOT_USER_ACTION=ignore \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN \
+    apk add --no-cache \
+        ca-certificates \
+        catatonit \
+        tzdata \
+    && pip install "hoymiles-mqtt==${VERSION}"
+
+USER nobody:nogroup
+
+ENTRYPOINT ["/usr/bin/catatonit", "--"]
+CMD ["python3", "-m", "hoymiles_mqtt"]

--- a/apps/hoymiles-mqtt/README.md
+++ b/apps/hoymiles-mqtt/README.md
@@ -1,0 +1,88 @@
+# hoymiles-mqtt
+
+Publishes Hoymiles DTU data to MQTT for Home Assistant discovery.
+
+## Quick Start
+
+Example local run:
+
+```bash
+docker run --rm \
+  -e MQTT_BROKER=192.168.1.10 \
+  -e DTU_HOST=192.168.1.20 \
+  -e LOG_TO_CONSOLE=true \
+  ghcr.io/joryirving/hoymiles-mqtt:rolling
+```
+
+## Configuration
+
+Required environment variables:
+
+| Config | Description | Default |
+|--------|-------------|---------|
+| MQTT_BROKER | Hostname or IP address of the MQTT broker | |
+| DTU_HOST | Hostname or IP address of the Hoymiles DTU | |
+
+Optional environment variables:
+
+| Config | Description | Default |
+|--------|-------------|---------|
+| MQTT_PORT | MQTT broker port | `1883` |
+| MQTT_USER | MQTT username | |
+| MQTT_PASSWORD | MQTT password | |
+| MQTT_TLS | Enable TLS for MQTT connection | `false` |
+| MQTT_TLS_INSECURE | Skip MQTT TLS certificate verification | `false` |
+| DTU_PORT | DTU Modbus TCP port | `502` |
+| MODBUS_UNIT_ID | DTU Modbus unit ID | `1` |
+| QUERY_PERIOD | Polling interval in seconds | `60` |
+| EXPIRE_AFTER | Mark entities unavailable after this many seconds | `0` |
+| COMM_TIMEOUT | Modbus request timeout in seconds | `3` |
+| COMM_RETRIES | Modbus retries per request | `3` |
+| COMM_RECONNECT_DELAY | Initial reconnect delay in seconds | `0` |
+| COMM_RECONNECT_DELAY_MAX | Maximum reconnect delay in seconds | `300` |
+| LOG_LEVEL | Python log level | `WARNING` |
+| LOG_TO_CONSOLE | Enable console logging | `false` |
+
+## Kubernetes Notes
+
+This container does not expose an inbound service. The pod only needs outbound access to:
+
+- the Hoymiles DTU on TCP `502`
+- your MQTT broker on its configured port
+
+For troubleshooting, set `LOG_TO_CONSOLE=true` and optionally `LOG_LEVEL=DEBUG`.
+
+Example deployment:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hoymiles-mqtt
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: hoymiles-mqtt
+  template:
+    metadata:
+      labels:
+        app: hoymiles-mqtt
+    spec:
+      containers:
+        - name: hoymiles-mqtt
+          image: ghcr.io/joryirving/hoymiles-mqtt:rolling
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            readOnlyRootFilesystem: true
+            allowPrivilegeEscalation: false
+          env:
+            - name: MQTT_BROKER
+              value: mqtt.default.svc
+            - name: DTU_HOST
+              value: 192.168.1.20
+            - name: LOG_TO_CONSOLE
+              value: "true"
+```

--- a/apps/hoymiles-mqtt/container_test.go
+++ b/apps/hoymiles-mqtt/container_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/hoymiles-mqtt:rolling")
+	testhelpers.TestCommandSucceeds(t, ctx, image, nil, "python3", "-m", "hoymiles_mqtt", "--help")
+}

--- a/apps/hoymiles-mqtt/docker-bake.hcl
+++ b/apps/hoymiles-mqtt/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "hoymiles-mqtt"
+}
+
+variable "VERSION" {
+  // renovate: datasource=pypi depName=hoymiles-mqtt
+  default = "0.11.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/wasilukm/hoymiles-mqtt"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
## Summary
- Add a new `apps/hoymiles-mqtt` image wired into this repository's bake/test conventions for running the Hoymiles DTU to MQTT bridge in Kubernetes.
- Build the image as rootless by default with a digest-pinned Python Alpine base and a single-process `python3 -m hoymiles_mqtt` runtime.
- Document required/optional environment variables and include a Kubernetes deployment example in the app README.

## Testing
- `docker buildx bake -f docker-bake.hcl image-local` (from `apps/hoymiles-mqtt`) ✅
- `docker run --rm hoymiles-mqtt:0.11.0 python3 -m hoymiles_mqtt --help` ✅
- `TEST_IMAGE=hoymiles-mqtt:0.11.0 go test . -v` (from `apps/hoymiles-mqtt`) ⚠️ fails locally in this environment because `testcontainers-go` cannot detect a rootless Docker provider.