### PR TITLE
feat: add promxy container image

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -39,12 +39,14 @@ jobs:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: '8'
           ai_primary_retry_delay_sec: '15'
-          ai_base_url: ${{ secrets.OPENAI_COMPATIBLE_URL }}
-          ai_model: ${{ secrets.OPENAI_COMPATIBLE_MODEL }}
-          ai_api_key: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
-          ai_fallback_base_url: ${{ secrets.OPENAI_COMPATIBLE_URL }}
-          ai_fallback_model: ${{ secrets.OPENAI_BACKUP_COMPATIBLE_MODEL }}
-          ai_fallback_api_key: ${{ secrets.OPENAI_COMPATIBLE_API_KEY }}
+          ai_base_url: ${{ vars.LITELLM_URL }}
+          ai_api_format: ${{ vars.PRIMARY_FORMAT }}
+          ai_model: ${{ vars.PRIMARY_MODEL }}
+          ai_api_key: ${{ secrets.LITELLM_API_KEY }}
+          ai_fallback_base_url: ${{ vars.LITELLM_URL }}
+          ai_fallback_api_format: ${{ vars.FALLBACK_FORMAT }}
+          ai_fallback_model: ${{ vars.FALLBACK_MODEL }}
+          ai_fallback_api_key: ${{ secrets.LITELLM_API_KEY }}
           allowed_source_hosts: '*'
           context_limit_mode: normal
           tool_mode: plan_execute_once

--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Analyze PR with reusable AI reviewer
         id: analyze
-        uses: misospace/pr-reviewer-action@5f399985e3c68f5cc470ffa5edb26792d6e6da29
+        uses: misospace/pr-reviewer-action@fbf128ba574db43ef6783c3d026bf59f9247c07c # v1.0.17
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: '8'

--- a/apps/promxy/.dockerignore
+++ b/apps/promxy/.dockerignore
@@ -1,0 +1,7 @@
+# NOTE: This file automatically copied to each applications
+# directory during build. Be careful not to ignore any files
+# that are needed in the build process.
+/*
+!defaults/
+!scripts/
+!entrypoint.sh

--- a/apps/promxy/Dockerfile
+++ b/apps/promxy/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/alpine:3.23
+ARG VERSION
+ARG TARGETARCH
+ARG SOURCE
+
+RUN apk add --no-cache \
+        ca-certificates \
+    && wget "https://github.com/jacksontj/promxy/releases/download/${VERSION}/promxy-${VERSION}-linux-${TARGETARCH}" \
+        -O /tmp/promxy \
+    && echo "$(grep "promxy-${VERSION}-linux-${TARGETARCH}" <(wget -qO- "https://github.com/jacksontj/promxy/releases/download/${VERSION}/SHA256SUMS") | cut -d' ' -f1)  /tmp/promxy" | sha256sum -c - \
+    && chmod +x /tmp/promxy \
+    && mv /tmp/promxy /bin/promxy \
+    && rm -rf /tmp/*
+
+USER nobody
+ENTRYPOINT ["/bin/promxy"]

--- a/apps/promxy/Dockerfile
+++ b/apps/promxy/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/alpine:3.23
+FROM docker.io/library/alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
 ARG VERSION
 ARG TARGETARCH
 ARG SOURCE
@@ -12,7 +12,9 @@ RUN apk add --no-cache \
     && echo "$(grep "promxy-${VERSION}-linux-${TARGETARCH}" <(wget -qO- "https://github.com/jacksontj/promxy/releases/download/${VERSION}/SHA256SUMS") | cut -d' ' -f1)  /tmp/promxy" | sha256sum -c - \
     && chmod +x /tmp/promxy \
     && mv /tmp/promxy /bin/promxy \
+    && mkdir -p /etc/promxy \
     && rm -rf /tmp/*
 
 USER nobody
 ENTRYPOINT ["/bin/promxy"]
+CMD ["--config=/etc/promxy/config.yaml"]

--- a/apps/promxy/container_test.go
+++ b/apps/promxy/container_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	ctx := context.Background()
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/promxy:rolling")
+	testhelpers.TestCommandSucceeds(t, ctx, image, nil, "/bin/promxy", "--version")
+}

--- a/apps/promxy/docker-bake.hcl
+++ b/apps/promxy/docker-bake.hcl
@@ -1,0 +1,43 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "promxy"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=jacksontj/promxy
+  default = "v0.0.93"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/jacksontj/promxy"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+    SOURCE = "${SOURCE}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
## Summary

Add a Promxy container image built from upstream release binaries.

## Changes

- `apps/promxy/Dockerfile` — Alpine 3.23 base, downloads prebuilt binary from upstream releases with SHA256 verification, runs as `nobody` (non-root)
- `apps/promxy/docker-bake.hcl` — build config with renovate-managed version bump, multi-arch (linux/amd64, linux/arm64), docker-metadata-action inheritance

## Details

- **Upstream**: jacksontj/promxy v0.0.93
- **Image**: ghcr.io/joryirving/promxy:v0.0.93
- **Entrypoint**: `/bin/promxy` (config path set via `--config` flag at deploy time)
- **No hardcoded config, endpoints, or secrets baked in