### PR TITLE
fix: sync III_VERSION to 0.12.0 in agentmemory docker-bake.hcl

### DIFF
--- a/apps/agentmemory/docker-bake.hcl
+++ b/apps/agentmemory/docker-bake.hcl
@@ -13,7 +13,8 @@ variable "SOURCE" {
 }
 
 variable "III_VERSION" {
-  default = "0.11.2"
+  // renovate: datasource=docker depName=docker.io/iiidev/iii
+  default = "0.12.0"
 }
 
 group "default" {


### PR DESCRIPTION
## fix: sync III_VERSION to 0.12.0 in docker-bake.hcl

Renovate updated the Dockerfile ARG to 0.12.0 but the docker-bake.hcl variable was not updated, causing version drift.

### Changes
- Updated `III_VERSION` default from `0.11.2` to `0.12.0`
- Added `// renovate: datasource=docker depName=docker.io/iiidev/iii` comment for Renovate

### Note on digest pinning
The iiidev/iii and node:22-slim base images use mutable tags. This is a pre-existing pattern in this Dockerfile. To fully digest-pin would require fetching the digest, which would need crane or similar tooling. This can be addressed in a follow-up if required by AGENTS.md policy.