### PR TITLE
fix: remove hardcoded III_VERSION default from Dockerfile

### DIFF
--- a/apps/agentmemory/Dockerfile
+++ b/apps/agentmemory/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 ARG VERSION
-ARG III_VERSION=0.11.2
+ARG III_VERSION
 ARG AGENTMEMORY_VERSION
 
 FROM docker.io/iiidev/iii:${III_VERSION} AS iii-image


### PR DESCRIPTION
## fix: remove hardcoded III_VERSION default from Dockerfile

The `III_VERSION` ARG had a hardcoded default of `0.11.2` in the Dockerfile. This creates version drift between the Dockerfile and docker-bake.hcl when Renovate updates one but not the other.

### Changes
- Removed `=0.11.2` default from `ARG III_VERSION` in Dockerfile
- The version is now provided exclusively via the `III_VERSION` bake variable, which is passed as a build arg