### PR TITLE
fix(agentmemory): add renovate annotation on VERSION

### DIFF
--- a/apps/agentmemory/docker-bake.hcl
+++ b/apps/agentmemory/docker-bake.hcl
@@ -5,6 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
+  // renovate: datasource=github-releases depName=rohitg00/agentmemory
   default = "0.9.21"
 }
 


### PR DESCRIPTION
Adds the missing `// renovate: datasource=github-releases depName=rohitg00/agentmemory` annotation above the `VERSION` variable in `apps/agentmemory/docker-bake.hcl`.

Without this annotation Renovate was not picking up new releases of [rohitg00/agentmemory](https://github.com/rohitg00/agentmemory) — every other app in this repo has a similar annotation on its VERSION variable, this one was just missing it.

The `SOURCE` variable on line 11 already points at `https://github.com/rohitg00/agentmemory`, so the `depName` matches the upstream identity.