### PR TITLE
fix(ci): stop label events from cancelling net-new PR reviews

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -8,7 +8,9 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # `labeled` events get their own group so an auto-applied label (Renovate
+  # adds several at PR creation) can't cancel the in-flight opened review.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}${{ github.event.action == 'labeled' && format('-label-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
Companion to the v1.2.9 label rollout: `labeled` events shared the concurrency group with `cancel-in-progress: true`, so an auto-applied label at PR creation could cancel the in-flight `opened` review and leave the PR unreviewed (root-caused on home-ops#7507, fixed there in joryirving/home-ops#7512). This isolates `labeled` events into their own concurrency group. No action change. A non-`ai-review` label add still spins a run, but the action's precheck no-ops it (no model call) and it reports success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)