### PR TITLE
chore(renovate): enable pip_requirements manager

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -1,6 +1,9 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>joryirving/renovate-config"],
+  pip_requirements: {
+    fileMatch: ["(^|/)requirements\\.txt$"],
+  },
   customManagers: [
     {
       customType: "regex",


### PR DESCRIPTION
Enables Renovate's built-in `pip_requirements` manager so `requirements.txt` files (e.g. `apps/hoymiles-exporter/requirements.txt`) are tracked for updates.

This unblocks keeping Python dependencies current alongside the existing `python:3.14-slim` Renovate bumps, but does not by itself fix the upstream `hoymiles_modbus<3.14` constraint blocking that bump.