### PR TITLE
chore(renovate): migrate pip_requirements fileMatch to managerFilePatterns

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -2,7 +2,7 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: ["github>joryirving/renovate-config"],
   pip_requirements: {
-    fileMatch: ["(^|/)requirements\\.txt$"],
+    managerFilePatterns: ["/(^|/)requirements\\.txt$/"],
   },
   customManagers: [
     {


### PR DESCRIPTION
## Summary
- Rename `pip_requirements.fileMatch` to `managerFilePatterns` (the deprecated key's current name) and slash-wrap the pattern so it stays a regex match. The custom managers in this file already use `managerFilePatterns`; this brings the built-in pip manager in line.

## Verification
- JSON5 parses clean.