### PR TITLE
ci(mise): auto-regenerate mise.lock on renovate PRs (stopgap)

### DIFF
--- a/.github/workflows/mise-lock.yaml
+++ b/.github/workflows/mise-lock.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+#
+# STOPGAP: Renovate bumps tool versions in .mise/config.toml but cannot
+# regenerate .mise/mise.lock for npm-backed tools (e.g. oxfmt = npm:oxfmt).
+# The renovate-operator container only has `mise` installed, not node, so
+# `mise lock` fails to resolve npm packages and the lock drifts from config.
+# That drift makes `mise install --locked` (Labeler) fail on every PR.
+#
+# This workflow regenerates the lockfile on a runner that has node available
+# and commits it back to the renovate branch. Remove once the lock is updated
+# at the source (node in the operator runtime, or oxfmt off the npm backend).
+name: Mise Lock
+
+on:
+  pull_request:
+    paths:
+      - .mise/config.toml
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  mise-lock:
+    if: ${{ github.actor == 'smurf-bot[bot]' && startsWith(github.head_ref, 'renovate/') }}
+    name: Mise Lock
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate Token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          client-id: ${{ secrets.BOT_CLIENT_ID }}
+          private-key: ${{ secrets.BOT_APP_PRIVATE_KEY }}
+          permission-contents: write
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
+
+      - name: Setup Mise
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4.1.0
+        with:
+          experimental: true
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Update Lockfile
+        id: lock
+        run: |
+          mise lock
+          if git diff --quiet -- .mise/mise.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit Lockfile
+        if: ${{ steps.lock.outputs.changed == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          gh api --method PUT "repos/${GITHUB_REPOSITORY}/contents/.mise/mise.lock" \
+            -f message="fix(mise): update lockfile" \
+            -f branch="${HEAD_REF}" \
+            -f sha="$(git rev-parse HEAD:.mise/mise.lock)" \
+            -f content="$(base64 -w0 .mise/mise.lock)"


### PR DESCRIPTION
## Summary
- Add a workflow that regenerates `.mise/mise.lock` on Renovate PRs touching `.mise/config.toml` and commits it back to the branch.

**This is a stopgap.** Renovate bumps tool versions in `config.toml` but can't update `mise.lock` for **npm-backed** tools — `oxfmt = npm:oxfmt`. The operator's renovate container has `mise` but not node, so `mise lock oxfmt` fails (`No such file or directory`) and the lock drifts. That drift makes `mise install --locked` in the Labeler workflow fail on **every** PR (it runs on `pull_request_target`). Other tools (aqua/core backends) lock fine — oxfmt is the only one that needs an external runtime.

## How it works
- Triggers on `pull_request` when `.mise/config.toml` changes, gated to `smurf-bot[bot]` + `renovate/*` branches.
- `jdx/mise-action` installs tools (so node is present → `npm:` backend resolves), then `mise lock` regenerates.
- Commits the lock via the Contents API as the bot → verified commit, keeps Renovate's branch ownership, re-triggers Labeler which then passes.

## Notes
- The real fix is upstream of this: node in the renovate runtime (matches how `home-operations` works), or moving oxfmt off the npm backend. Remove this workflow once that's done.
- The `lockFileMaintenance` mise rule in renovate-config becomes redundant for keeping config↔lock in sync once this is in place.

## Verification
- YAML parses clean. End-to-end behavior verifies on the next Renovate mise bump.