### PR TITLE
ci(github-action): bump pr-reviewer-action to v2.0.0

### DIFF
--- a/.github/workflows/ai-pr-review.yaml
+++ b/.github/workflows/ai-pr-review.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Analyze PR with reusable AI reviewer
         if: github.event_name == 'pull_request'
         id: analyze
-        uses: misospace/pr-reviewer-action@7189223d79151d0508bdb1c60b6e60097e998ce5 # v1.3.1
+        uses: misospace/pr-reviewer-action@7e25f7d0d8651e936f3158477b0a364f27ed7383 # v2.0.0
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           ai_primary_retries: "3"


### PR DESCRIPTION
Bumps the AI reviewer pin v1.3.1 → v2.0.0 (`7e25f7d`).

Verified 2.0-compatible before bumping: config already uses `tool_mode: native_loop` (the plan_execute modes removed in 2.0), no `ai_fast_*` inputs, and `publish_mode: review_verdict`. Pin-line only. Renovate hadn't opened this bump for containers (it did for the 5 misospace repos).