### PR TITLE
fix(mise): regenerate lockfile to restore oxfmt

### DIFF
--- a/.mise/mise.lock
+++ b/.mise/mise.lock
@@ -181,6 +181,10 @@ url = "https://nodejs.org/dist/v26.3.1/node-v26.3.1-darwin-x64.tar.gz"
 checksum = "sha256:45001b289ebffe7b22260898f3750059183d8246042b88e8ffa4337e65e6763e"
 url = "https://nodejs.org/dist/v26.3.1/node-v26.3.1-win-x64.zip"
 
+[[tools.oxfmt]]
+version = "0.56.0"
+backend = "npm:oxfmt"
+
 [[tools.shellcheck]]
 version = "0.11.0"
 backend = "aqua:koalaman/shellcheck"


### PR DESCRIPTION
Regenerates `.mise/mise.lock` with a node-equipped `mise lock`, restoring the `oxfmt` entry that was missing on `main`.

**Why CI was red on every PR:** the renovate operator regenerates the lock in a container that has `node` but no `npm` and never runs `mise install`, so mise cannot resolve the npm-backed `oxfmt` and silently drops it. `mise install --locked` (Plan + Labeler) then fails with `oxfmt@0.56.0 is not in the lockfile` regardless of what the PR changes.

Verified the regenerated lock passes `mise install --locked` on mise `2026.6.12`.

Durable fix (operator runs `mise install && mise lock` via `postUpgradeTasks`) is in separate PRs to `renovate-config` and `home-ops`. The `mise-lock.yaml` stopgap stays until that is confirmed working.

Note: the `Labeler` check on this PR runs via `pull_request_target` against `main`, so it will stay red until this merges — merging is what fixes it.