### PR TITLE
feat(foreman-dispatch-bridge): per-repo gateProfile via GATEPROFILE_MAP

### DIFF
--- a/apps/foreman-dispatch-bridge/README.md
+++ b/apps/foreman-dispatch-bridge/README.md
@@ -31,6 +31,21 @@ pytest -v
 - `DISPATCH_URL` (default `http://dispatch.llm:3000`), `DISPATCH_AGENT_TOKEN`
 - `DISPATCH_AGENT_NAME` (default `foreman/coder`), `DISPATCH_LANES` (default `local,cloud,frontier`)
 - `FOREMAN_NAMESPACE` (default `llm`)
+- `GATEPROFILE_MAP` (optional, JSON): maps `owner/repo` → a Foreman
+  [`GateProfile`](https://llmkube.com/docs/foreman/language-gates), stamped on
+  each Workload's `spec.gateProfile` so non-Go repos run their own language
+  gate (needs Foreman ≥ 0.8.23, which propagates it to the decomposed tasks).
+  Absent → no `gateProfile` → Foreman's Go default. A `"*"` key is the
+  fallback for repos without their own entry. Preset images are minimal, so
+  set `commands` (install-in-command) for repos with real toolchains:
+
+  ```json
+  {
+    "misospace/dispatch":   {"language": "node",   "commands": {"test": "corepack pnpm i && corepack pnpm test"}},
+    "misospace/miso-gallery": {"language": "python", "commands": {"test": "pip install -q -e . && pytest -q"}},
+    "*": {"language": "generic"}
+  }
+  ```
 
 ## Status
 

--- a/apps/foreman-dispatch-bridge/bridge/main.py
+++ b/apps/foreman-dispatch-bridge/bridge/main.py
@@ -1,7 +1,7 @@
 import os
 from typing import Callable, Optional
 from bridge.models import ClaimedItem
-from bridge.workload import build_workload, gate_profile_for
+from bridge.workload import build_workload, gate_profile_for, parse_gate_profiles
 
 ClaimOne = Callable[[str, str], Optional[ClaimedItem]]  # (agent_name, lane) -> item | None
 
@@ -37,7 +37,6 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
     import requests
     from kubernetes import client, config
     from bridge.claim import DispatchClient
-    from bridge.workload import parse_gate_profiles
 
     base_url = os.environ.get("DISPATCH_URL", "http://dispatch.llm:3000")
     token = os.environ["DISPATCH_AGENT_TOKEN"]

--- a/apps/foreman-dispatch-bridge/bridge/main.py
+++ b/apps/foreman-dispatch-bridge/bridge/main.py
@@ -1,7 +1,7 @@
 import os
 from typing import Callable, Optional
 from bridge.models import ClaimedItem
-from bridge.workload import build_workload
+from bridge.workload import build_workload, gate_profile_for
 
 ClaimOne = Callable[[str, str], Optional[ClaimedItem]]  # (agent_name, lane) -> item | None
 
@@ -12,15 +12,22 @@ def run_once(
     claim_one: ClaimOne,
     create_workload: Callable[[dict], None],
     namespace: str,
+    gate_profiles: Optional[dict] = None,
 ) -> list:
-    """Claim one ready issue per lane and materialize a Workload for each. Returns per-lane outcomes."""
+    """Claim one ready issue per lane and materialize a Workload for each. Returns per-lane outcomes.
+
+    gate_profiles maps "owner/repo" -> a Foreman GateProfile dict; the matching
+    profile (or the "*" wildcard) is stamped on each Workload so non-Go repos
+    run their own language gate. None/empty leaves gateProfile off (Go default).
+    """
+    gate_profiles = gate_profiles or {}
     results = []
     for lane in lanes:
         item = claim_one(agent_name, lane)
         if item is None:
             results.append(f"{lane}:empty")
             continue
-        manifest = build_workload(item, namespace)
+        manifest = build_workload(item, namespace, gate_profile_for(item.repo, gate_profiles))
         create_workload(manifest)
         results.append(f"{lane}:created:{manifest['metadata']['name']}")
     return results
@@ -30,12 +37,14 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
     import requests
     from kubernetes import client, config
     from bridge.claim import DispatchClient
+    from bridge.workload import parse_gate_profiles
 
     base_url = os.environ.get("DISPATCH_URL", "http://dispatch.llm:3000")
     token = os.environ["DISPATCH_AGENT_TOKEN"]
     agent_name = os.environ.get("DISPATCH_AGENT_NAME", "foreman/coder")
     lanes = [l.strip() for l in os.environ.get("DISPATCH_LANES", "local,cloud,frontier").split(",") if l.strip()]
     namespace = os.environ.get("FOREMAN_NAMESPACE", "llm")
+    gate_profiles = parse_gate_profiles(os.environ.get("GATEPROFILE_MAP"))
 
     def http_get(url, headers):
         r = requests.get(url, headers=headers, timeout=20)
@@ -64,7 +73,7 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
             if e.status != 409:  # 409 = Workload already exists -> idempotent no-op
                 raise
 
-    for line in run_once(lanes, agent_name, dispatch.claim_one, create_workload, namespace):
+    for line in run_once(lanes, agent_name, dispatch.claim_one, create_workload, namespace, gate_profiles):
         print(line)
 
 

--- a/apps/foreman-dispatch-bridge/bridge/workload.py
+++ b/apps/foreman-dispatch-bridge/bridge/workload.py
@@ -1,3 +1,6 @@
+import json
+from typing import Optional
+
 from bridge.models import ClaimedItem
 
 # Single coder for the MVP (all lanes route to it); Ornith reviews, deterministic gate verifies.
@@ -5,13 +8,63 @@ CODER_AGENT = "coder"
 VERIFIER_AGENT = "gate"
 REVIEWER_AGENTS = ["reviewer"]
 
+# Fallback key in a gate-profile map: its profile applies to any repo that has
+# no entry of its own.
+GATE_PROFILE_WILDCARD = "*"
+
+
+def parse_gate_profiles(raw: Optional[str]) -> dict:
+    """Parse the GATEPROFILE_MAP env var (JSON object: repo -> GateProfile).
+
+    Empty or absent -> {}, so every Workload omits gateProfile and Foreman
+    falls back to its Go gate (unchanged behavior). Each value is passed
+    through verbatim as Workload.spec.gateProfile, so the full CRD shape is
+    expressible from config:
+
+        {
+          "misospace/dispatch": {"language": "node",
+                                 "commands": {"test": "corepack pnpm i && corepack pnpm test"}},
+          "misospace/miso-gallery": {"language": "python",
+                                     "commands": {"test": "pip install -q -e . && pytest -q"}},
+          "*": {"language": "generic"}
+        }
+
+    A bare {"language": "node"} uses the preset's stock image (node:22), which
+    ships no eslint/prettier/test deps -- set commands (install-in-command) or
+    a pre-baked image for repos with real toolchains.
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def gate_profile_for(repo: str, gate_profiles: dict) -> Optional[dict]:
+    """Resolve a repo's gate profile: exact match, then the "*" wildcard, else None."""
+    if not gate_profiles:
+        return None
+    return gate_profiles.get(repo) or gate_profiles.get(GATE_PROFILE_WILDCARD)
+
 
 def workload_name(item: ClaimedItem) -> str:
     owner_repo = item.repo.replace("/", "-").lower()
     return f"wl-{owner_repo}-{item.issue_number}"
 
 
-def build_workload(item: ClaimedItem, namespace: str) -> dict:
+def build_workload(item: ClaimedItem, namespace: str, gate_profile: Optional[dict] = None) -> dict:
+    spec = {
+        "intent": item.intent,
+        "repo": item.repo,
+        "issues": [item.issue_number],
+        "coderAgentRef": {"name": CODER_AGENT},
+        "verifierAgentRef": {"name": VERIFIER_AGENT},
+        "reviewerAgentRefs": [{"name": name} for name in REVIEWER_AGENTS],
+    }
+    if gate_profile:
+        # Passed through verbatim. Foreman >= 0.8.23 copies Workload.spec.gateProfile
+        # onto every decomposed AgenticTask (the coder self-gate + verify Job), so a
+        # non-Go repo runs its own language gate instead of the Go default.
+        spec["gateProfile"] = gate_profile
     return {
         "apiVersion": "foreman.llmkube.dev/v1alpha1",
         "kind": "Workload",
@@ -20,12 +73,5 @@ def build_workload(item: ClaimedItem, namespace: str) -> dict:
             "namespace": namespace,
             "labels": {"created-by": "dispatch-bridge", "lane": item.lane},
         },
-        "spec": {
-            "intent": item.intent,
-            "repo": item.repo,
-            "issues": [item.issue_number],
-            "coderAgentRef": {"name": CODER_AGENT},
-            "verifierAgentRef": {"name": VERIFIER_AGENT},
-            "reviewerAgentRefs": [{"name": name} for name in REVIEWER_AGENTS],
-        },
+        "spec": spec,
     }

--- a/apps/foreman-dispatch-bridge/docker-bake.hcl
+++ b/apps/foreman-dispatch-bridge/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.1.0"
+  default = "0.2.0"
 }
 
 variable "SOURCE" {

--- a/apps/foreman-dispatch-bridge/tests/test_main.py
+++ b/apps/foreman-dispatch-bridge/tests/test_main.py
@@ -29,6 +29,31 @@ def test_all_empty_creates_nothing():
     assert created == []
 
 
+def test_stamps_matching_gate_profile_on_workload():
+    created = []
+    item = ClaimedItem(repo="misospace/dispatch", issue_number=7, intent="fix", lane="local")
+    profiles = {"misospace/dispatch": {"language": "node"}, "*": {"language": "generic"}}
+    run_once(LANES, "foreman/coder", _claim_stub({"local": item}),
+             created.append, namespace="llm", gate_profiles=profiles)
+    assert created[0]["spec"]["gateProfile"] == {"language": "node"}
+
+
+def test_unmatched_repo_falls_back_to_wildcard_gate_profile():
+    created = []
+    item = ClaimedItem(repo="misospace/windowstead", issue_number=1, intent="fix", lane="cloud")
+    profiles = {"misospace/dispatch": {"language": "node"}, "*": {"language": "generic"}}
+    run_once(LANES, "foreman/coder", _claim_stub({"cloud": item}),
+             created.append, namespace="llm", gate_profiles=profiles)
+    assert created[0]["spec"]["gateProfile"] == {"language": "generic"}
+
+
+def test_no_gate_profiles_leaves_workload_without_one():
+    created = []
+    item = ClaimedItem(repo="a/b", issue_number=3, intent="fix", lane="local")
+    run_once(LANES, "foreman/coder", _claim_stub({"local": item}), created.append, namespace="llm")
+    assert "gateProfile" not in created[0]["spec"]
+
+
 def test_passes_agent_name_and_lane_through():
     seen = []
     def claim_one(agent_name, lane):

--- a/apps/foreman-dispatch-bridge/tests/test_workload.py
+++ b/apps/foreman-dispatch-bridge/tests/test_workload.py
@@ -1,5 +1,10 @@
 from bridge.models import ClaimedItem
-from bridge.workload import workload_name, build_workload
+from bridge.workload import (
+    workload_name,
+    build_workload,
+    parse_gate_profiles,
+    gate_profile_for,
+)
 
 ITEM = ClaimedItem(repo="joryirving/home-ops", issue_number=42,
                    intent="Fix the flaky reconcile test", lane="local")
@@ -25,3 +30,40 @@ def test_build_workload_structure():
     assert wl["spec"]["repo"] == "joryirving/home-ops"
     assert wl["spec"]["issues"] == [42]
     assert wl["spec"]["intent"] == "Fix the flaky reconcile test"
+
+
+def test_build_workload_omits_gate_profile_by_default():
+    # No profile -> no gateProfile key, so Foreman keeps its Go default.
+    assert "gateProfile" not in build_workload(ITEM, namespace="llm")["spec"]
+
+
+def test_build_workload_passes_gate_profile_through_verbatim():
+    profile = {"language": "node", "commands": {"test": "corepack pnpm i && corepack pnpm test"}}
+    wl = build_workload(ITEM, namespace="llm", gate_profile=profile)
+    assert wl["spec"]["gateProfile"] == profile
+
+
+def test_parse_gate_profiles_empty_is_empty_dict():
+    assert parse_gate_profiles(None) == {}
+    assert parse_gate_profiles("") == {}
+    assert parse_gate_profiles("   ") == {}
+
+
+def test_parse_gate_profiles_parses_json_map():
+    raw = '{"misospace/dispatch": {"language": "node"}, "*": {"language": "generic"}}'
+    assert parse_gate_profiles(raw) == {
+        "misospace/dispatch": {"language": "node"},
+        "*": {"language": "generic"},
+    }
+
+
+def test_gate_profile_for_prefers_exact_match_then_wildcard():
+    profiles = {"misospace/dispatch": {"language": "node"}, "*": {"language": "generic"}}
+    assert gate_profile_for("misospace/dispatch", profiles) == {"language": "node"}
+    # Unmatched repo falls back to the wildcard.
+    assert gate_profile_for("misospace/miso-chat", profiles) == {"language": "generic"}
+
+
+def test_gate_profile_for_returns_none_when_no_match_and_no_wildcard():
+    assert gate_profile_for("misospace/miso-chat", {"misospace/dispatch": {"language": "node"}}) is None
+    assert gate_profile_for("a/b", {}) is None


### PR DESCRIPTION
## Summary
- Add optional `GATEPROFILE_MAP` env var (JSON `owner/repo` → Foreman `GateProfile`); the matching profile (or a `"*"` fallback) is stamped on each Workload's `spec.gateProfile`, so non-Go repos run their own language gate instead of Foreman's Go default.
- Profiles pass through verbatim — `language`/`image`/`commands`/`sourceExtensions` are all config-driven from the home-ops env.
- Absent/empty map → no `gateProfile` (unchanged behavior).

## Notes
- Needs Foreman ≥ 0.8.23 to take effect (that release propagates `Workload.spec.gateProfile` to the decomposed AgenticTasks — defilantech/LLMKube#920). The field is safe to set on older operators; it's just ignored.
- Preset images are minimal (`node:22` has no eslint/prettier; `python:3.13` has no ruff/pytest), so real repos need `commands` (install-in-command) or a pre-baked image — documented in the README with examples.
- Verification: `pytest -q` → 22 passed (6 new: passthrough, omit-by-default, parse, exact/wildcard/miss resolution, main-loop stamping). `VERSION` 0.1.0 → 0.2.0.

## Follow-up (not in this PR)
- Wire `GATEPROFILE_MAP` into the home-ops bridge HelmRelease with per-repo commands once defilantech/LLMKube#924 (per-task repo clone) ships and each repo's exact test command is confirmed.