### PR TITLE
feat(foreman-dispatch-bridge): escalate exhausted workloads to a stronger lane (0.4.0)

### DIFF
--- a/apps/foreman-dispatch-bridge/bridge/claim.py
+++ b/apps/foreman-dispatch-bridge/bridge/claim.py
@@ -87,3 +87,31 @@ class DispatchClient:
         if not self.claim(item, agent_name):
             return None
         return to_claimed_item(item, lane)
+
+    def set_lane(self, item: ClaimedItem, lane: str, reason: str) -> bool:
+        """Record an explicit lane classification for the issue (manual override)."""
+        payload = {
+            "model": "bridge-escalation",
+            "classification": {"lane": lane, "confidence": "high", "reason": reason},
+        }
+        url = f"{self._base}/api/issues/{item.issue_id}/lane"
+        return self._post(url, self._headers(), payload) is not None
+
+    def unclaim(self, item: ClaimedItem, agent_name: str) -> bool:
+        """Release the bridge's claim so the issue is claimable again."""
+        payload = {
+            "issueId": item.issue_id,
+            "repoFullName": item.repo,
+            "issueNumber": item.issue_number,
+            "agentName": agent_name,
+        }
+        return self._post(f"{self._base}/api/issues/unclaim", self._headers(), payload) is not None
+
+    def escalate(self, item: ClaimedItem, lane: str, reason: str, agent_name: str) -> bool:
+        """Move a given-up issue to the escalation lane and release the claim.
+
+        Lane first, then unclaim: if the unclaim fails the issue stays claimed
+        (so nothing re-serves it into a loop) and the caller keeps the Failed
+        Workload tombstone, so the next tick retries the escalation.
+        """
+        return self.set_lane(item, lane, reason) and self.unclaim(item, agent_name)

--- a/apps/foreman-dispatch-bridge/bridge/main.py
+++ b/apps/foreman-dispatch-bridge/bridge/main.py
@@ -2,7 +2,13 @@ import os
 import time
 from typing import Callable, Optional
 from bridge.models import ClaimedItem
-from bridge.workload import build_workload, gate_profile_for, parse_gate_profiles
+from bridge.workload import (
+    build_workload,
+    coder_agent_for,
+    gate_profile_for,
+    parse_gate_profiles,
+    parse_lane_coder_agents,
+)
 from bridge.retry import reconcile_failures, DEFAULT_MAX_ATTEMPTS
 
 ClaimOne = Callable[[str, str], Optional[ClaimedItem]]  # (agent_name, lane) -> item | None
@@ -15,21 +21,33 @@ def run_once(
     create_workload: Callable[[dict], None],
     namespace: str,
     gate_profiles: Optional[dict] = None,
+    lane_coder_agents: Optional[dict] = None,
 ) -> list:
     """Claim one ready issue per lane and materialize a Workload for each. Returns per-lane outcomes.
 
     gate_profiles maps "owner/repo" -> a Foreman GateProfile dict; the matching
     profile (or the "*" wildcard) is stamped on each Workload so non-Go repos
     run their own language gate. None/empty leaves gateProfile off (Go default).
+
+    lane_coder_agents maps a lane -> a coder Agent name (with "*" wildcard), so
+    an escalation lane can route to a stronger (e.g. cloud-proxy) coder.
+    None/empty routes every lane to the default coder.
     """
     gate_profiles = gate_profiles or {}
+    lane_coder_agents = lane_coder_agents or {}
     results = []
     for lane in lanes:
         item = claim_one(agent_name, lane)
         if item is None:
             results.append(f"{lane}:empty")
             continue
-        manifest = build_workload(item, namespace, gate_profile_for(item.repo, gate_profiles))
+        manifest = build_workload(
+            item,
+            namespace,
+            gate_profile_for(item.repo, gate_profiles),
+            agent_name,
+            coder_agent=coder_agent_for(item.lane, lane_coder_agents),
+        )
         create_workload(manifest)
         results.append(f"{lane}:created:{manifest['metadata']['name']}")
     return results
@@ -47,6 +65,11 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
     namespace = os.environ.get("FOREMAN_NAMESPACE", "llm")
     gate_profiles = parse_gate_profiles(os.environ.get("GATEPROFILE_MAP"))
     max_attempts = int(os.environ.get("RETRY_MAX_ATTEMPTS", str(DEFAULT_MAX_ATTEMPTS)))
+    # Lane -> coder Agent map, e.g. '{"*": "coder", "frontier": "coder-frontier"}'.
+    lane_coder_agents = parse_lane_coder_agents(os.environ.get("LANE_CODER_AGENTS"))
+    # When set, exhausted Workloads outside this lane escalate into it (re-lane +
+    # unclaim) instead of tombstoning. Empty disables escalation.
+    escalation_lane = os.environ.get("ESCALATION_LANE", "").strip()
 
     def http_get(url, headers):
         r = requests.get(url, headers=headers, timeout=20)
@@ -112,15 +135,28 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
             time.sleep(1)
         raise TimeoutError(f"workload {name} still terminating after 60s")
 
+    def escalate(item: ClaimedItem) -> bool:
+        reason = (
+            f"bridge escalation: {max_attempts} failed attempts in lane "
+            f"'{item.lane or '?'}' for {item.repo}#{item.issue_number}"
+        )
+        return dispatch.escalate(item, escalation_lane, reason, agent_name)
+
     # Retry failed workloads first (so a re-run this tick uses the current config),
     # then claim new work.
     for line in reconcile_failures(
         agent_name, list_failed_workloads, create_workload, delete_workload,
         namespace, gate_profiles, max_attempts,
+        escalate=escalate if escalation_lane else None,
+        escalation_lane=escalation_lane,
+        lane_coder_agents=lane_coder_agents,
     ):
         print(line)
 
-    for line in run_once(lanes, agent_name, dispatch.claim_one, create_workload, namespace, gate_profiles):
+    for line in run_once(
+        lanes, agent_name, dispatch.claim_one, create_workload, namespace,
+        gate_profiles, lane_coder_agents,
+    ):
         print(line)
 
 

--- a/apps/foreman-dispatch-bridge/bridge/retry.py
+++ b/apps/foreman-dispatch-bridge/bridge/retry.py
@@ -1,8 +1,9 @@
-from typing import Callable
+from typing import Callable, Optional
 
 from bridge.models import ClaimedItem
 from bridge.workload import (
     build_workload,
+    coder_agent_for,
     gate_profile_for,
     ATTEMPT_ANNOTATION,
     ISSUE_ID_ANNOTATION,
@@ -14,6 +15,7 @@ DEFAULT_MAX_ATTEMPTS = 3
 
 ListFailed = Callable[[], list]         # () -> list of Failed Workload manifests (dicts)
 DeleteWorkload = Callable[[str], None]  # (name) -> None; blocks until the object is gone
+Escalate = Callable[[ClaimedItem], bool]  # (item) -> True when re-laned + unclaimed
 
 
 def attempt_of(wl: dict) -> int:
@@ -50,6 +52,9 @@ def reconcile_failures(
     namespace: str,
     gate_profiles: dict,
     max_attempts: int = DEFAULT_MAX_ATTEMPTS,
+    escalate: Optional[Escalate] = None,
+    escalation_lane: str = "",
+    lane_coder_agents: Optional[dict] = None,
 ) -> list:
     """Retry Failed bridge Workloads, bounded by max_attempts.
 
@@ -58,18 +63,36 @@ def reconcile_failures(
         so it re-runs with the current config (gateProfile, agent refs). The name
         is deterministic, so delete-then-recreate reuses the same name/branch;
         delete_workload must block until the old object is gone.
-      - attempt >= max_attempts: leave it as a Failed tombstone (no action). The
-        issue stays claimed so the groomer won't re-serve it into a loop; a human
-        triages from the lingering Workload.
+      - attempt >= max_attempts, not yet in the escalation lane, and an escalate
+        hook is wired: move the issue to the escalation lane + release the claim,
+        then delete the Workload. The next tick claims it from the escalation
+        lane and builds a fresh Workload with that lane's coder Agent. If the
+        escalate call fails, keep the tombstone so the next tick retries it.
+      - attempt >= max_attempts otherwise (already escalated, or no hook): leave
+        it as a Failed tombstone (no action). The issue stays claimed so the
+        groomer won't re-serve it into a loop; a human triages from the
+        lingering Workload.
 
     Returns per-Workload outcome strings.
     """
+    lane_coder_agents = lane_coder_agents or {}
     results = []
     for wl in list_failed():
         name = ((wl.get("metadata") or {}).get("name")) or "?"
         attempt = attempt_of(wl)
         if attempt >= max_attempts:
-            results.append(f"{name}:giveup:{attempt}/{max_attempts}")
+            item = item_from_workload(wl)
+            can_escalate = (
+                escalate is not None
+                and escalation_lane
+                and item.lane != escalation_lane
+                and item.issue_id
+            )
+            if can_escalate and escalate(item):
+                delete_workload(name)
+                results.append(f"{name}:escalated:{item.lane or '?'}->{escalation_lane}")
+            else:
+                results.append(f"{name}:giveup:{attempt}/{max_attempts}")
             continue
         item = item_from_workload(wl)
         delete_workload(name)
@@ -79,6 +102,7 @@ def reconcile_failures(
             gate_profile_for(item.repo, gate_profiles),
             agent_name,
             attempt + 1,
+            coder_agent_for(item.lane, lane_coder_agents),
         )
         create_workload(manifest)
         results.append(f"{name}:retry:{attempt + 1}/{max_attempts}")

--- a/apps/foreman-dispatch-bridge/bridge/workload.py
+++ b/apps/foreman-dispatch-bridge/bridge/workload.py
@@ -3,10 +3,14 @@ from typing import Optional
 
 from bridge.models import ClaimedItem
 
-# Single coder for the MVP (all lanes route to it); Ornith reviews, deterministic gate verifies.
+# Default coder when a lane has no explicit mapping; Ornith reviews, deterministic gate verifies.
 CODER_AGENT = "coder"
 VERIFIER_AGENT = "gate"
 REVIEWER_AGENTS = ["reviewer"]
+
+# Fallback key in a lane->coder-agent map: its agent applies to any lane that
+# has no entry of its own.
+LANE_CODER_WILDCARD = "*"
 
 # Fallback key in a gate-profile map: its profile applies to any repo that has
 # no entry of its own.
@@ -52,6 +56,28 @@ def gate_profile_for(repo: str, gate_profiles: dict) -> Optional[dict]:
     return gate_profiles.get(repo) or gate_profiles.get(GATE_PROFILE_WILDCARD)
 
 
+def parse_lane_coder_agents(raw: Optional[str]) -> dict:
+    """Parse the LANE_CODER_AGENTS env var (JSON object: lane -> coder Agent name).
+
+    Empty or absent -> {}, so every lane routes to the default coder Agent
+    (unchanged behavior). Example wiring the escalation tier to a cloud-proxy
+    coder:
+
+        {"*": "coder", "frontier": "coder-frontier"}
+    """
+    raw = (raw or "").strip()
+    if not raw:
+        return {}
+    return json.loads(raw)
+
+
+def coder_agent_for(lane: str, lane_coder_agents: dict) -> str:
+    """Resolve a lane's coder Agent: exact match, then "*", else the default coder."""
+    if not lane_coder_agents:
+        return CODER_AGENT
+    return lane_coder_agents.get(lane) or lane_coder_agents.get(LANE_CODER_WILDCARD) or CODER_AGENT
+
+
 def workload_name(item: ClaimedItem) -> str:
     owner_repo = item.repo.replace("/", "-").lower()
     return f"wl-{owner_repo}-{item.issue_number}"
@@ -63,12 +89,13 @@ def build_workload(
     gate_profile: Optional[dict] = None,
     agent_name: str = "",
     attempt: int = 1,
+    coder_agent: str = CODER_AGENT,
 ) -> dict:
     spec = {
         "intent": item.intent,
         "repo": item.repo,
         "issues": [item.issue_number],
-        "coderAgentRef": {"name": CODER_AGENT},
+        "coderAgentRef": {"name": coder_agent},
         "verifierAgentRef": {"name": VERIFIER_AGENT},
         "reviewerAgentRefs": [{"name": name} for name in REVIEWER_AGENTS],
     }

--- a/apps/foreman-dispatch-bridge/docker-bake.hcl
+++ b/apps/foreman-dispatch-bridge/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.3.0"
+  default = "0.4.0"
 }
 
 variable "SOURCE" {

--- a/apps/foreman-dispatch-bridge/tests/test_claim.py
+++ b/apps/foreman-dispatch-bridge/tests/test_claim.py
@@ -67,3 +67,55 @@ def test_claim_one_empty_queue():
                             http_get=lambda u, h: [],
                             http_post=lambda u, h, p: {"ok": True})
     assert client.claim_one("foreman/coder", "local") is None
+
+
+def _client_recording_posts(responses=None):
+    from bridge.claim import DispatchClient
+    posts = []
+    resp = list(responses or [])
+
+    def http_post(url, headers, payload):
+        posts.append((url, payload))
+        return resp.pop(0) if resp else {}
+
+    return DispatchClient("http://d", "tok", lambda u, h: [], http_post), posts
+
+
+def test_set_lane_posts_manual_classification():
+    from bridge.models import ClaimedItem
+    c, posts = _client_recording_posts()
+    item = ClaimedItem(repo="a/b", issue_number=7, intent="t", lane="local", issue_id="id-7")
+    assert c.set_lane(item, "frontier", "3 failed attempts") is True
+    url, payload = posts[0]
+    assert url == "http://d/api/issues/id-7/lane"
+    assert payload["model"] == "bridge-escalation"
+    assert payload["classification"] == {"lane": "frontier", "confidence": "high",
+                                         "reason": "3 failed attempts"}
+
+
+def test_unclaim_posts_release():
+    from bridge.models import ClaimedItem
+    c, posts = _client_recording_posts()
+    item = ClaimedItem(repo="a/b", issue_number=7, intent="t", lane="local", issue_id="id-7")
+    assert c.unclaim(item, "foreman-coder") is True
+    url, payload = posts[0]
+    assert url == "http://d/api/issues/unclaim"
+    assert payload == {"issueId": "id-7", "repoFullName": "a/b", "issueNumber": 7,
+                       "agentName": "foreman-coder"}
+
+
+def test_escalate_stops_after_failed_lane_move():
+    from bridge.models import ClaimedItem
+    # First POST (lane) -> None (failure); unclaim must NOT run.
+    c, posts = _client_recording_posts(responses=[None])
+    item = ClaimedItem(repo="a/b", issue_number=7, intent="t", lane="local", issue_id="id-7")
+    assert c.escalate(item, "frontier", "r", "foreman-coder") is False
+    assert len(posts) == 1
+
+
+def test_escalate_lane_then_unclaim():
+    from bridge.models import ClaimedItem
+    c, posts = _client_recording_posts(responses=[{}, {}])
+    item = ClaimedItem(repo="a/b", issue_number=7, intent="t", lane="local", issue_id="id-7")
+    assert c.escalate(item, "frontier", "r", "foreman-coder") is True
+    assert [u for u, _ in posts] == ["http://d/api/issues/id-7/lane", "http://d/api/issues/unclaim"]

--- a/apps/foreman-dispatch-bridge/tests/test_retry.py
+++ b/apps/foreman-dispatch-bridge/tests/test_retry.py
@@ -80,3 +80,54 @@ def test_reconcile_empty_is_noop():
     r = _Recorder([])
     assert reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
                               namespace="llm", gate_profiles={}, max_attempts=3) == []
+
+
+def test_reconcile_escalates_at_max_when_hook_wired():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=3, lane="local", issue_id="id-7")])
+    escalated = []
+
+    def escalate(item):
+        escalated.append(item)
+        return True
+
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                             "llm", {}, max_attempts=3,
+                             escalate=escalate, escalation_lane="frontier")
+    assert out == ["wl-a-b-7:escalated:local->frontier"]
+    assert [i.issue_id for i in escalated] == ["id-7"]
+    assert r.deleted == ["wl-a-b-7"]   # tombstone removed after successful escalation
+    assert r.created == []             # the next tick's claim builds the frontier Workload
+
+
+def test_reconcile_keeps_tombstone_when_escalate_fails():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=3)])
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                             "llm", {}, max_attempts=3,
+                             escalate=lambda item: False, escalation_lane="frontier")
+    assert out == ["wl-a-b-7:giveup:3/3"]
+    assert r.deleted == []             # keep the tombstone; next tick retries escalation
+
+
+def test_reconcile_never_escalates_out_of_the_escalation_lane():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=3, lane="frontier")])
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                             "llm", {}, max_attempts=3,
+                             escalate=lambda item: True, escalation_lane="frontier")
+    assert out == ["wl-a-b-7:giveup:3/3"]
+    assert r.deleted == []
+
+
+def test_reconcile_requires_issue_id_to_escalate():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=3, issue_id="")])
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                             "llm", {}, max_attempts=3,
+                             escalate=lambda item: True, escalation_lane="frontier")
+    assert out == ["wl-a-b-7:giveup:3/3"]
+
+
+def test_reconcile_retry_uses_lane_coder_agent():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=1, lane="frontier")])
+    reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                       "llm", {}, max_attempts=3,
+                       lane_coder_agents={"*": "coder", "frontier": "coder-frontier"})
+    assert r.created[0]["spec"]["coderAgentRef"] == {"name": "coder-frontier"}

--- a/apps/foreman-dispatch-bridge/tests/test_workload.py
+++ b/apps/foreman-dispatch-bridge/tests/test_workload.py
@@ -79,3 +79,24 @@ def test_gate_profile_for_prefers_exact_match_then_wildcard():
 def test_gate_profile_for_returns_none_when_no_match_and_no_wildcard():
     assert gate_profile_for("misospace/miso-chat", {"misospace/dispatch": {"language": "node"}}) is None
     assert gate_profile_for("a/b", {}) is None
+
+
+def test_parse_lane_coder_agents_empty_is_empty_dict():
+    from bridge.workload import parse_lane_coder_agents
+    assert parse_lane_coder_agents(None) == {}
+    assert parse_lane_coder_agents("") == {}
+    assert parse_lane_coder_agents("  ") == {}
+
+
+def test_coder_agent_for_prefers_exact_then_wildcard_then_default():
+    from bridge.workload import coder_agent_for
+    agents = {"*": "coder", "frontier": "coder-frontier"}
+    assert coder_agent_for("frontier", agents) == "coder-frontier"
+    assert coder_agent_for("local", agents) == "coder"
+    assert coder_agent_for("local", {"frontier": "coder-frontier"}) == "coder"  # no wildcard -> default
+    assert coder_agent_for("anything", {}) == "coder"
+
+
+def test_build_workload_uses_explicit_coder_agent():
+    wl = build_workload(ITEM, "llm", coder_agent="coder-frontier")
+    assert wl["spec"]["coderAgentRef"] == {"name": "coder-frontier"}


### PR DESCRIPTION
## Summary
- Give-up path can now escalate instead of tombstoning: re-lane the issue to `ESCALATION_LANE` (`POST /api/issues/{id}/lane`, `model: bridge-escalation`, confidence high) → unclaim → delete the dead Workload. Next tick claims it from the escalation lane. Failed escalation keeps the tombstone and retries next tick; issues already in the escalation lane still tombstone (nowhere left to go).
- `LANE_CODER_AGENTS` (JSON `{lane: agentName}` with `"*"` wildcard) sets `Workload.spec.coderAgentRef` per lane — so `frontier` can route to a cloud-proxy coder (MiniMax-M3 via litellm).
- Fresh workloads now stamp the `agent-name` annotation (previously only retries did), so escalation can unclaim them.

Both opt-in via env; unset preserves 0.3.0 behavior.

## Verification
- `pytest tests/ -q` → 42 passed (12 new).