### PR TITLE
feat(foreman-dispatch-bridge): feedback-carrying retries + issue-id backfill (0.5.0)

### DIFF
--- a/apps/foreman-dispatch-bridge/bridge/claim.py
+++ b/apps/foreman-dispatch-bridge/bridge/claim.py
@@ -107,6 +107,18 @@ class DispatchClient:
         }
         return self._post(f"{self._base}/api/issues/unclaim", self._headers(), payload) is not None
 
+    def find_issue_id(self, agent_name: str, lanes: list, repo: str, issue_number: int) -> str:
+        """Recover a dispatch issue id by repo+number from the lane queues
+        (includeClaimed=true, so claimed items are visible). Used to backfill
+        Workloads whose issue-id annotation predates bridge 0.3.0."""
+        for lane in lanes:
+            for item in self.queue(agent_name, lane):
+                if not isinstance(item, dict):
+                    continue
+                if item.get("repoFullName") == repo and int(_number(item) or 0) == issue_number:
+                    return str(item.get("issueId") or item.get("id") or "")
+        return ""
+
     def escalate(self, item: ClaimedItem, lane: str, reason: str, agent_name: str) -> bool:
         """Move a given-up issue to the escalation lane and release the claim.
 

--- a/apps/foreman-dispatch-bridge/bridge/main.py
+++ b/apps/foreman-dispatch-bridge/bridge/main.py
@@ -9,7 +9,7 @@ from bridge.workload import (
     parse_gate_profiles,
     parse_lane_coder_agents,
 )
-from bridge.retry import reconcile_failures, DEFAULT_MAX_ATTEMPTS
+from bridge.retry import reconcile_failures, feedback_from_tasks, DEFAULT_MAX_ATTEMPTS
 
 ClaimOne = Callable[[str, str], Optional[ClaimedItem]]  # (agent_name, lane) -> item | None
 
@@ -135,6 +135,28 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
             time.sleep(1)
         raise TimeoutError(f"workload {name} still terminating after 60s")
 
+    def list_workload_tasks(workload_name: str) -> list:
+        resp = api.list_namespaced_custom_object(
+            group="foreman.llmkube.dev", version="v1alpha1",
+            namespace=namespace, plural="agentictasks",
+            label_selector=f"foreman.llmkube.dev/workload={workload_name}",
+        )
+        return resp.get("items", [])
+
+    def feedback_for(workload_name: str) -> str:
+        try:
+            return feedback_from_tasks(list_workload_tasks(workload_name))
+        except Exception as e:  # feedback is best-effort; never block a retry on it
+            print(f"{workload_name}:feedback-lookup-failed:{e}")
+            return ""
+
+    def lookup_issue_id(item: ClaimedItem) -> str:
+        try:
+            return dispatch.find_issue_id(agent_name, lanes, item.repo, item.issue_number)
+        except Exception as e:  # best-effort; missing id just means no escalation
+            print(f"{item.repo}#{item.issue_number}:issue-id-lookup-failed:{e}")
+            return ""
+
     def escalate(item: ClaimedItem) -> bool:
         reason = (
             f"bridge escalation: {max_attempts} failed attempts in lane "
@@ -150,6 +172,8 @@ def _real_main() -> None:  # pragma: no cover - thin wiring, exercised in the cl
         escalate=escalate if escalation_lane else None,
         escalation_lane=escalation_lane,
         lane_coder_agents=lane_coder_agents,
+        lookup_issue_id=lookup_issue_id,
+        feedback_for=feedback_for,
     ):
         print(line)
 

--- a/apps/foreman-dispatch-bridge/bridge/retry.py
+++ b/apps/foreman-dispatch-bridge/bridge/retry.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from typing import Callable, Optional
 
 from bridge.models import ClaimedItem
@@ -16,6 +17,53 @@ DEFAULT_MAX_ATTEMPTS = 3
 ListFailed = Callable[[], list]         # () -> list of Failed Workload manifests (dicts)
 DeleteWorkload = Callable[[str], None]  # (name) -> None; blocks until the object is gone
 Escalate = Callable[[ClaimedItem], bool]  # (item) -> True when re-laned + unclaimed
+LookupIssueId = Callable[[ClaimedItem], str]   # (item) -> dispatch issue id, "" if not found
+FeedbackFor = Callable[[str], str]             # (workload name) -> retry feedback text, "" if none
+
+
+# Bounds the feedback block injected into a retry's coder prompt.
+FEEDBACK_MAX_CHARS = 2000
+
+
+def feedback_from_tasks(tasks: list) -> str:
+    """Distill a failed Workload's task results into a retry prompt block.
+
+    Sources, in order of usefulness: a reviewer NO-GO's structured findings
+    (missing_tests / scope_creep / *_details), then reviewer summaries, then
+    coder failure errors. Returns "" when there is nothing actionable, so the
+    caller falls back to a plain (issues-path) retry.
+    """
+    notes = []
+    for t in tasks or []:
+        spec = t.get("spec") or {}
+        st = t.get("status") or {}
+        ex = (st.get("result") or {}).get("extra") or {}
+        kind = spec.get("kind")
+        if kind == "review" and st.get("verdict") == "NO-GO":
+            me = ex.get("modelExtra") or {}
+            findings = me.get("findings") or {}
+            flags = sorted(k for k, v in findings.items() if v is True and not k.endswith("_details"))
+            details = [f"{k}: {v}" for k, v in sorted(findings.items()) if isinstance(v, str) and v]
+            summary = ex.get("modelSummary") or ""
+            parts = []
+            if flags:
+                parts.append("findings: " + ", ".join(flags))
+            parts.extend(details)
+            if summary:
+                parts.append(summary)
+            if parts:
+                notes.append("Reviewer rejected the previous attempt (NO-GO). " + "; ".join(parts))
+        elif kind == "issue-fix" and st.get("verdict") in ("NO-GO", "INCOMPLETE"):
+            err = ex.get("error") or ""
+            if err:
+                notes.append(f"Previous coder attempt failed: {err}")
+    if not notes:
+        return ""
+    text = (
+        "A previous automated attempt at this issue was rejected. "
+        "Address this feedback in your fix:\n- " + "\n- ".join(notes)
+    )
+    return text[:FEEDBACK_MAX_CHARS]
 
 
 def attempt_of(wl: dict) -> int:
@@ -55,6 +103,8 @@ def reconcile_failures(
     escalate: Optional[Escalate] = None,
     escalation_lane: str = "",
     lane_coder_agents: Optional[dict] = None,
+    lookup_issue_id: Optional[LookupIssueId] = None,
+    feedback_for: Optional[FeedbackFor] = None,
 ) -> list:
     """Retry Failed bridge Workloads, bounded by max_attempts.
 
@@ -82,6 +132,11 @@ def reconcile_failures(
         attempt = attempt_of(wl)
         if attempt >= max_attempts:
             item = item_from_workload(wl)
+            if not item.issue_id and lookup_issue_id:
+                # Workloads created before the issue-id annotation (bridge <0.3.0)
+                # carry "" forever through retries; recover the id from the
+                # dispatch queue so they can still escalate.
+                item = replace(item, issue_id=lookup_issue_id(item) or "")
             can_escalate = (
                 escalate is not None
                 and escalation_lane
@@ -95,6 +150,10 @@ def reconcile_failures(
                 results.append(f"{name}:giveup:{attempt}/{max_attempts}")
             continue
         item = item_from_workload(wl)
+        # Collect the previous attempt's review findings / failure BEFORE the
+        # delete (the tasks go with the Workload). A retry that knows why it
+        # was rejected beats a blind identical re-run.
+        feedback = feedback_for(name) if feedback_for else ""
         delete_workload(name)
         manifest = build_workload(
             item,
@@ -103,6 +162,7 @@ def reconcile_failures(
             agent_name,
             attempt + 1,
             coder_agent_for(item.lane, lane_coder_agents),
+            feedback=feedback,
         )
         create_workload(manifest)
         results.append(f"{name}:retry:{attempt + 1}/{max_attempts}")

--- a/apps/foreman-dispatch-bridge/bridge/workload.py
+++ b/apps/foreman-dispatch-bridge/bridge/workload.py
@@ -83,6 +83,42 @@ def workload_name(item: ClaimedItem) -> str:
     return f"wl-{owner_repo}-{item.issue_number}"
 
 
+def _pipeline_steps(item: ClaimedItem, name: str, coder_agent: str, feedback: str) -> list:
+    """Explicit spec.pipeline mirroring the operator's issues-path decomposition
+    (code -> verify -> review-*), with the retry feedback injected as the code
+    step's payload.prompt — the only channel that reaches the coder's user
+    prompt ("Issue context"). Branch naming matches the issues path so re-runs
+    keep the same branch. gateProfile still propagates: the operator stamps the
+    Workload default onto every rendered step."""
+    n = item.issue_number
+    branch = f"foreman/{name}/issue-{n}"
+    payload = {"repo": item.repo, "issue": n, "branch": branch}
+    steps = [
+        {
+            "name": f"code-{n}",
+            "kind": "issue-fix",
+            "agentRef": {"name": coder_agent},
+            "payload": {**payload, "prompt": feedback},
+        },
+        {
+            "name": f"verify-{n}",
+            "kind": "verify",
+            "agentRef": {"name": VERIFIER_AGENT},
+            "dependsOn": [f"code-{n}"],
+            "payload": dict(payload),
+        },
+    ]
+    for i, reviewer in enumerate(REVIEWER_AGENTS):
+        steps.append({
+            "name": f"review-{n}-{i}",
+            "kind": "review",
+            "agentRef": {"name": reviewer},
+            "dependsOn": [f"verify-{n}"],
+            "payload": dict(payload),
+        })
+    return steps
+
+
 def build_workload(
     item: ClaimedItem,
     namespace: str,
@@ -90,15 +126,25 @@ def build_workload(
     agent_name: str = "",
     attempt: int = 1,
     coder_agent: str = CODER_AGENT,
+    feedback: str = "",
 ) -> dict:
-    spec = {
-        "intent": item.intent,
-        "repo": item.repo,
-        "issues": [item.issue_number],
-        "coderAgentRef": {"name": coder_agent},
-        "verifierAgentRef": {"name": VERIFIER_AGENT},
-        "reviewerAgentRefs": [{"name": name} for name in REVIEWER_AGENTS],
-    }
+    if feedback:
+        # Retry with context: explicit pipeline so payload.prompt can carry the
+        # previous attempt's review findings / failure to the coder.
+        spec = {
+            "intent": item.intent,
+            "repo": item.repo,
+            "pipeline": _pipeline_steps(item, workload_name(item), coder_agent, feedback),
+        }
+    else:
+        spec = {
+            "intent": item.intent,
+            "repo": item.repo,
+            "issues": [item.issue_number],
+            "coderAgentRef": {"name": coder_agent},
+            "verifierAgentRef": {"name": VERIFIER_AGENT},
+            "reviewerAgentRefs": [{"name": name} for name in REVIEWER_AGENTS],
+        }
     if gate_profile:
         # Passed through verbatim. Foreman >= 0.8.23 copies Workload.spec.gateProfile
         # onto every decomposed AgenticTask (the coder self-gate + verify Job), so a

--- a/apps/foreman-dispatch-bridge/docker-bake.hcl
+++ b/apps/foreman-dispatch-bridge/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.4.0"
+  default = "0.5.0"
 }
 
 variable "SOURCE" {

--- a/apps/foreman-dispatch-bridge/tests/test_claim.py
+++ b/apps/foreman-dispatch-bridge/tests/test_claim.py
@@ -119,3 +119,19 @@ def test_escalate_lane_then_unclaim():
     item = ClaimedItem(repo="a/b", issue_number=7, intent="t", lane="local", issue_id="id-7")
     assert c.escalate(item, "frontier", "r", "foreman-coder") is True
     assert [u for u, _ in posts] == ["http://d/api/issues/id-7/lane", "http://d/api/issues/unclaim"]
+
+
+def test_find_issue_id_scans_lanes_and_matches_repo_number():
+    from bridge.claim import DispatchClient
+    queues = {
+        "local": [{"repoFullName": "a/b", "number": 9, "issueId": "id-9"}],
+        "frontier": [{"repoFullName": "a/b", "number": 7, "issueId": "id-7"}],
+    }
+
+    def http_get(url, headers):
+        lane = url.split("lane=")[1].split("&")[0]
+        return queues.get(lane, [])
+
+    c = DispatchClient("http://d", "tok", http_get, lambda u, h, p: {})
+    assert c.find_issue_id("agent", ["local", "frontier"], "a/b", 7) == "id-7"
+    assert c.find_issue_id("agent", ["local", "frontier"], "a/b", 99) == ""

--- a/apps/foreman-dispatch-bridge/tests/test_retry.py
+++ b/apps/foreman-dispatch-bridge/tests/test_retry.py
@@ -131,3 +131,86 @@ def test_reconcile_retry_uses_lane_coder_agent():
                        "llm", {}, max_attempts=3,
                        lane_coder_agents={"*": "coder", "frontier": "coder-frontier"})
     assert r.created[0]["spec"]["coderAgentRef"] == {"name": "coder-frontier"}
+
+
+def _no_go_review(findings=None, summary=""):
+    return {
+        "spec": {"kind": "review"},
+        "status": {"verdict": "NO-GO", "phase": "Succeeded",
+                   "result": {"extra": {"modelExtra": {"findings": findings or {}},
+                                        "modelSummary": summary}}},
+    }
+
+
+def test_feedback_from_tasks_distills_review_no_go():
+    from bridge.retry import feedback_from_tasks
+    tasks = [_no_go_review(
+        findings={"missing_tests": True, "scope_creep": True,
+                  "scope_creep_details": "commit reduces token lifetime, unrelated to #141"},
+    )]
+    fb = feedback_from_tasks(tasks)
+    assert "Reviewer rejected the previous attempt" in fb
+    assert "missing_tests" in fb and "scope_creep" in fb
+    assert "unrelated to #141" in fb
+
+
+def test_feedback_from_tasks_includes_coder_errors_and_bounds_length():
+    from bridge.retry import feedback_from_tasks, FEEDBACK_MAX_CHARS
+    tasks = [{
+        "spec": {"kind": "issue-fix"},
+        "status": {"verdict": "INCOMPLETE",
+                   "result": {"extra": {"error": "x" * 5000}}},
+    }]
+    fb = feedback_from_tasks(tasks)
+    assert "Previous coder attempt failed" in fb
+    assert len(fb) <= FEEDBACK_MAX_CHARS
+
+
+def test_feedback_from_tasks_empty_when_nothing_actionable():
+    from bridge.retry import feedback_from_tasks
+    assert feedback_from_tasks([]) == ""
+    assert feedback_from_tasks([{"spec": {"kind": "verify"}, "status": {"verdict": "GATE-PASS"}}]) == ""
+
+
+def test_reconcile_retry_carries_feedback_into_pipeline_prompt():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=1)])
+    reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                       "llm", {}, max_attempts=3,
+                       feedback_for=lambda name: "Reviewer said: add tests")
+    spec = r.created[0]["spec"]
+    assert "pipeline" in spec and "issues" not in spec
+    code_step = spec["pipeline"][0]
+    assert code_step["payload"]["prompt"] == "Reviewer said: add tests"
+    # verify + review steps present and chained
+    assert [st["name"] for st in spec["pipeline"]] == ["code-7", "verify-7", "review-7-0"]
+    assert spec["pipeline"][1]["dependsOn"] == ["code-7"]
+
+
+def test_reconcile_retry_without_feedback_stays_on_issues_path():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=1)])
+    reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                       "llm", {}, max_attempts=3,
+                       feedback_for=lambda name: "")
+    spec = r.created[0]["spec"]
+    assert "issues" in spec and "pipeline" not in spec
+
+
+def test_reconcile_backfills_issue_id_before_escalating():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=3, issue_id="")])
+    escalated = []
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                             "llm", {}, max_attempts=3,
+                             escalate=lambda item: escalated.append(item) or True,
+                             escalation_lane="frontier",
+                             lookup_issue_id=lambda item: "recovered-id")
+    assert out == ["wl-a-b-7:escalated:local->frontier"]
+    assert escalated[0].issue_id == "recovered-id"
+
+
+def test_reconcile_still_gives_up_when_backfill_finds_nothing():
+    r = _Recorder([_failed_wl("wl-a-b-7", attempt=3, issue_id="")])
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, r.delete,
+                             "llm", {}, max_attempts=3,
+                             escalate=lambda item: True, escalation_lane="frontier",
+                             lookup_issue_id=lambda item: "")
+    assert out == ["wl-a-b-7:giveup:3/3"]


### PR DESCRIPTION
## Summary
- **Retries carry the rejection reason.** Before deleting a Failed Workload, read its tasks' results (reviewer NO-GO structured findings + details + summary, coder failure errors) via the `foreman.llmkube.dev/workload` label. With actionable feedback, the retry is built as an explicit `spec.pipeline` (code→verify→review, same names/branch as the operator's issues path) with the feedback in the code step's `payload.prompt` — rendered into the coder's "Issue context". No feedback → plain issues-path retry as before. Feedback capped at 2k chars.
- **Issue-id backfill at give-up.** Pre-0.3.0 Workloads carry an empty `issue-id` annotation forever and can't escalate; the bridge now recovers the id from the dispatch lane queues (repo+number match, `includeClaimed=true`) before deciding escalate-vs-tombstone.

Why: overnight, 4 review-NO-GO issues burned all 3 attempts on byte-identical re-runs — the coder never learned why Ornith rejected it (e.g. `scope_creep: commit reduces token lifetime, unrelated to #141`, `missing_tests`). That exact text now lands in the retry prompt.

## Deploy note
- Requires RBAC `get/list` on `agentictasks` for the bridge Role (home-ops PR to follow — safe to apply before the image bump).

## Verification
- `pytest tests/ -q` → 50 passed (8 new).