### PR TITLE
fix(foreman-dispatch-bridge): isolate per-workload retry failures (0.5.1)

### DIFF
--- a/apps/foreman-dispatch-bridge/bridge/retry.py
+++ b/apps/foreman-dispatch-bridge/bridge/retry.py
@@ -154,16 +154,24 @@ def reconcile_failures(
         # delete (the tasks go with the Workload). A retry that knows why it
         # was rejected beats a blind identical re-run.
         feedback = feedback_for(name) if feedback_for else ""
-        delete_workload(name)
-        manifest = build_workload(
-            item,
-            namespace,
-            gate_profile_for(item.repo, gate_profiles),
-            agent_name,
-            attempt + 1,
-            coder_agent_for(item.lane, lane_coder_agents),
-            feedback=feedback,
-        )
-        create_workload(manifest)
+        # Per-workload isolation: a delete that wedges (e.g. a Workload whose
+        # deletion never completes, LLMKube#949) or a create that races must
+        # not abort the rest of the reconcile pass and the claim pass — one
+        # bad Workload previously crashed the whole bridge run every tick.
+        try:
+            delete_workload(name)
+            manifest = build_workload(
+                item,
+                namespace,
+                gate_profile_for(item.repo, gate_profiles),
+                agent_name,
+                attempt + 1,
+                coder_agent_for(item.lane, lane_coder_agents),
+                feedback=feedback,
+            )
+            create_workload(manifest)
+        except Exception as e:
+            results.append(f"{name}:retry-error:{e}")
+            continue
         results.append(f"{name}:retry:{attempt + 1}/{max_attempts}")
     return results

--- a/apps/foreman-dispatch-bridge/docker-bake.hcl
+++ b/apps/foreman-dispatch-bridge/docker-bake.hcl
@@ -5,7 +5,7 @@ variable "APP" {
 }
 
 variable "VERSION" {
-  default = "0.5.0"
+  default = "0.5.1"
 }
 
 variable "SOURCE" {

--- a/apps/foreman-dispatch-bridge/tests/test_retry.py
+++ b/apps/foreman-dispatch-bridge/tests/test_retry.py
@@ -214,3 +214,20 @@ def test_reconcile_still_gives_up_when_backfill_finds_nothing():
                              escalate=lambda item: True, escalation_lane="frontier",
                              lookup_issue_id=lambda item: "")
     assert out == ["wl-a-b-7:giveup:3/3"]
+
+
+def test_reconcile_isolates_a_wedged_delete():
+    """A delete that raises (e.g. LLMKube#949's immortal Workload) must not
+    abort the remaining retries."""
+    r = _Recorder([_failed_wl("wl-wedged", attempt=1), _failed_wl("wl-fine", attempt=1)])
+
+    def delete(name):
+        if name == "wl-wedged":
+            raise TimeoutError("workload wl-wedged still terminating after 60s")
+        r.deleted.append(name)
+
+    out = reconcile_failures("foreman-coder", r.list_failed, r.create, delete,
+                             "llm", {}, max_attempts=3)
+    assert out[0].startswith("wl-wedged:retry-error:")
+    assert out[1] == "wl-fine:retry:2/3"
+    assert len(r.created) == 1  # only the healthy one was recreated


### PR DESCRIPTION
## Summary
- Wrap each Workload's delete/recreate in the retry pass; a failure becomes a `name:retry-error:<err>` line instead of crashing the run.

LLMKube#949 (operator resynthesizes children on a terminating Workload → foreground delete never completes) made `delete_workload` raise `TimeoutError` and abort the whole bridge tick — reconcile AND claim passes — every hour, wedged on one immortal Workload. Upstream fix is defilantech/LLMKube#950; this makes the bridge degrade gracefully regardless.

## Verification
- `pytest tests/ -q` → 51 passed (1 new: wedged delete doesn't block the healthy workload's retry).