### PR TITLE
fix(home-assistant): reconcile persisted venv deps on boot

### DIFF
--- a/apps/home-assistant/Dockerfile
+++ b/apps/home-assistant/Dockerfile
@@ -7,6 +7,10 @@ ARG TARGETARCH
 ARG ARCH=${TARGETARCH/arm64/aarch64}
 ARG VERSION
 
+# Persisted so the entrypoint can reconcile the persisted venv against the
+# exact HA version baked into this image on every boot.
+ENV VERSION=${VERSION}
+
 ENV \
     CRYPTOGRAPHY_DONT_BUILD_RUST=1 \
     PIP_BREAK_SYSTEM_PACKAGES=1 \

--- a/apps/home-assistant/entrypoint.sh
+++ b/apps/home-assistant/entrypoint.sh
@@ -6,8 +6,18 @@ mkdir -p "${VENV_FOLDER}"
 uv venv --system-site-packages --link-mode=copy --allow-existing "${VENV_FOLDER}"
 source "${VENV_FOLDER}/bin/activate"
 
+# System site-packages (baked into the image) acts as a find-links index.
 site_packages=$(python -c "import sysconfig; print(sysconfig.get_path('purelib'))")
-uv pip install --no-index --find-links="${site_packages}" uv
+
+# Reconcile the persisted venv with the image's pinned deps on every boot.
+# Without this, a stale aiohttp (or any other dep) carried over in the PVC
+# shadows the image's newer version and breaks HA at runtime (e.g. HA's
+# websocket_api passing `decode_text=` to an aiohttp that predates it).
+uv pip install \
+    --no-index \
+    --find-links="${site_packages}" \
+    uv \
+    "homeassistant==${VERSION}"
 
 ln -sf /proc/self/fd/1 /config/home-assistant.log
 


### PR DESCRIPTION
## Problem

Home Assistant 2026.7.0 broke the dashboard after the image bump: the login page (HTTP) loads, but the dashboard never connects — `Unable to connect to Home Assistant. Retrying...` — reproducing even at the direct LoadBalancer IP (`10.69.10.133:8123`), which rules out HTTPRoute/Envoy/multus/trusted-proxy.

## Root cause

The pod log shows every WebSocket upgrade dying with:

```
File ".../homeassistant/components/websocket_api/http.py", line 98, in __init__
    self._wsock = web.WebSocketResponse(heartbeat=55, decode_text=False)
TypeError: WebSocketResponse.__init__() got an unexpected keyword argument 'decode_text'
```

`decode_text` was added in aiohttp **3.14.0**. The persisted venv on the `config-cache` PVC (mounted at `/config/.venv`) was stuck at aiohttp **3.13.3** from a prior image, shadowing the image's correct aiohttp **3.14.1** in `/usr/local/...`. Confirmed live in the pod:

| Location | aiohttp | has `decode_text` |
| --- | --- | --- |
| image (`/usr/local/lib/...`) | 3.14.1 | ✅ |
| venv PVC (`/config/.venv/lib/...`) | 3.13.3 | ❌ |

HA 2026.7.0 pins `aiohttp==3.14.1`. The frontend (HTTP) serves fine; the dashboard (WebSocket) crashes on every connect attempt.

The `entrypoint.sh` only re-installed `uv` into the reused venv on each boot — it never reconciled HA's dependency tree — so stale deps carried forward across every image bump.

## Fix

`entrypoint.sh` now installs `homeassistant==${VERSION}` into the venv on every boot, pulling its pinned deps (e.g. aiohttp 3.14.1) from the image's site-packages as a `--find-links` index, so the persisted venv stays in sync with the image:

```bash
uv pip install \
    --no-index \
    --find-links="${site_packages}" \
    uv \
    "homeassistant==${VERSION}"
```

Also persists the build-time `VERSION` ARG as an `ENV` in the Dockerfile, since ARGs don't reach the container environment at runtime (verified: `VERSION` was `<unset>` in the running pod).

## Verification

- HA 2026.7.0 metadata confirms `aiohttp==3.14.1` requirement.
- aiohttp 3.14.1 has `decode_text` (signature check passed); 3.13.3 does not.
- The only material venv/image mismatch is aiohttp — two other "newer in venv" packages (`aiohappyeyeballs`, `typing_extensions`) satisfy their constraints harmlessly.
- Image's system site-packages exposes `homeassistant-2026.7.0` and `aiohttp-3.14.1` dist-info, so the find-links mechanism can satisfy the install.
- `shellcheck -x entrypoint.sh` → clean (exit 0).

## After merge

Rebuild + push the image; Flux will roll the new pod, the entrypoint will reconcile the venv on first boot, and the dashboard will connect. No PVC wipe needed — the entrypoint now self-heals the venv.

🤖 Generated with ZCode