### PR TITLE
feat(llmkube-coder): coder agent from source + Python/Node self-gate toolchain

### DIFF
--- a/apps/llmkube-coder/Dockerfile
+++ b/apps/llmkube-coder/Dockerfile
@@ -1,0 +1,92 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: cross-compile the static foreman-agent from LLMKube source.
+# CGO is disabled, so the binary runs on the Python/Node runtime below with no
+# Go toolchain present. Pinned to $BUILDPLATFORM + GOOS/GOARCH so the compiler
+# always runs natively (arm64 never pays QEMU's interpreted-compile cost).
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS build
+ARG VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ENV CGO_ENABLED=0
+WORKDIR /build
+# Resolve VERSION to the module's version string so the stamped binary reports a
+# real release (the FleetNode heartbeats main.Version; an empty stamp shows as
+# "dev" in `kubectl get fleetnodes`). go list -m needs a module context.
+RUN mkdir -p /out /tmp/vresolve \
+    && ( cd /tmp/vresolve && go mod init coderbuild >/dev/null 2>&1 \
+         && go list -m -f '{{.Version}}' "github.com/defilantech/llmkube@v${VERSION}" > /out/llmkube.version ) \
+    && LLMKUBE_VERSION="$(cat /out/llmkube.version)" \
+    && GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" go install -trimpath \
+         -ldflags="-s -w -X main.Version=${LLMKUBE_VERSION} -X main.GitCommit=v${VERSION}" \
+         "github.com/defilantech/llmkube/cmd/foreman-agent@v${VERSION}" \
+    && cp "$(find "$(go env GOPATH)/bin" -name foreman-agent -type f | head -1)" /out/foreman-agent \
+    && test -x /out/foreman-agent
+
+# Node source stage: the official Node 22 image on the same Debian base as the
+# runtime, so the copied binary is ABI-compatible.
+FROM node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4 AS node
+
+# Runtime: Python 3.14 + Node 22 (the languages this fleet's coder self-gate
+# targets) + git + the linters the gate runs. No Go: the target repos are
+# Python/Node and the agent binary is static.
+FROM python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
+
+LABEL org.opencontainers.image.title="llmkube-coder" \
+      org.opencontainers.image.description="LLMKube foreman coder agent (built from source) with a Python + Node self-gate toolchain" \
+      org.opencontainers.image.source="https://github.com/defilantech/LLMKube" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# git for the coder workspace; libstdc++6 is Node's only runtime dep beyond the
+# python-slim base.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node 22 + npm from the official image.
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+    && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx \
+    && node --version && npm --version
+
+# Python self-gate linters.
+# renovate: datasource=pypi depName=ruff
+ARG RUFF_VERSION=0.15.20
+# renovate: datasource=pypi depName=black
+ARG BLACK_VERSION=26.5.1
+# renovate: datasource=pypi depName=flake8
+ARG FLAKE8_VERSION=7.3.0
+# renovate: datasource=pypi depName=yamllint
+ARG YAMLLINT_VERSION=1.38.0
+RUN pip install --no-cache-dir \
+      "ruff==${RUFF_VERSION}" "black==${BLACK_VERSION}" \
+      "flake8==${FLAKE8_VERSION}" "yamllint==${YAMLLINT_VERSION}"
+
+# Node self-gate linters.
+# renovate: datasource=npm depName=eslint
+ARG ESLINT_VERSION=10.6.0
+# renovate: datasource=npm depName=prisma
+ARG PRISMA_VERSION=7.8.0
+# renovate: datasource=npm depName=typescript
+ARG TYPESCRIPT_VERSION=6.0.3
+RUN npm install -g --no-fund --no-audit \
+      "eslint@${ESLINT_VERSION}" "prisma@${PRISMA_VERSION}" "typescript@${TYPESCRIPT_VERSION}" \
+    && rm -rf /root/.npm
+
+# Read-only-rootfs friendly: all writable state under /tmp, and git operates on
+# the workspace regardless of the (possibly pod-overridden) uid.
+ENV HOME=/tmp \
+    npm_config_cache=/tmp/.npm \
+    PIP_CACHE_DIR=/tmp/.pip
+RUN git config --system --add safe.directory '*'
+
+COPY --from=build /out/foreman-agent /foreman-agent
+RUN chmod 0755 /foreman-agent \
+    && ln -sf /foreman-agent /usr/local/bin/foreman-agent
+
+# nobody:nogroup (repo default). The foreman pod may override the uid; the image
+# is uid-agnostic — all writable state lives in /tmp and the tools are
+# world-executable.
+USER 65534:65534
+ENTRYPOINT ["/foreman-agent"]

--- a/apps/llmkube-coder/container_test.go
+++ b/apps/llmkube-coder/container_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/llmkube-coder:rolling")
+	testhelpers.TestFileExists(t, image, "/foreman-agent", nil)
+	// The agent binary and both language toolchains the coder self-gate uses.
+	testhelpers.TestCommandSucceeds(t, image, nil, "foreman-agent", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "python3", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "node", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "npm", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "git", "--version")
+	// Representative Python + Node linters.
+	testhelpers.TestCommandSucceeds(t, image, nil, "ruff", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "eslint", "--version")
+}

--- a/apps/llmkube-coder/docker-bake.hcl
+++ b/apps/llmkube-coder/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "llmkube-coder"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=defilantech/LLMKube
+  default = "0.9.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/defilantech/LLMKube"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
## Summary
- New `apps/llmkube-coder`: the foreman coder agent built **from LLMKube source** on a **Python 3.14 + Node 22** runtime with the self-gate linters.

## Why
The published `defilantech/llmkube-foreman-agent-coder` is Go-toolchain only. Our foreman fleet targets Python (KubeTix, miso-gallery, pr-reviewer-action) and Node (dispatch), so the coder can't run its in-workspace self-gate (`pytest`/`ruff`/`eslint`/`tsc`) and ships unverified changes that then fail the clean-room gate. This gives it a language-matched environment.

## How
- **Build stage** (`golang`, throwaway): cross-compile the static `foreman-agent@v${VERSION}` from LLMKube source, version-stamped via `go list -m` so the FleetNode reports a real release (not `dev`). `CGO_ENABLED=0` → runs on the runtime with no Go present.
- **Runtime** (`python:3.14-slim`): Node 22 + npm copied from `node:22-slim` (same Debian base); `git`; pip `ruff/black/flake8/yamllint`; npm `eslint/prisma/typescript` — matching the `GATEPROFILE_MAP` gate commands.
- **Renovate** tracks the LLMKube release tag (`docker-bake` `VERSION`, `github-releases defilantech/LLMKube`), so this rebuilds on each release, independent of the upstream coder-image publish cadence. Tool pins + FROM digests are Renovate-managed too.
- Multi-arch amd64/arm64 (Go cross-compiled in `$BUILDPLATFORM`); digest-pinned bases; non-root `65534` (uid-agnostic — writable state in `/tmp`, `git safe.directory '*'`, world-executable tools — so a foreman pod may override the uid).

## Notes
- Couldn't build locally (no docker daemon); CI does the multi-arch build + `container_test.go` smoke (agent `--version` + python/node/git/ruff/eslint present).
- Consumed by pointing the home-ops foreman chart `image.repository` at `ghcr.io/joryirving/llmkube-coder` (separate PR once this publishes).
