### PR TITLE
feat(llmkube-coder): add python and node single-language coder images

### DIFF
--- a/apps/llmkube-coder-node/Dockerfile
+++ b/apps/llmkube-coder-node/Dockerfile
@@ -1,0 +1,66 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: cross-compile the static foreman-agent from LLMKube source.
+# CGO is disabled, so the binary runs on the Node runtime below with no
+# Go toolchain present. Pinned to $BUILDPLATFORM + GOOS/GOARCH so the compiler
+# always runs natively (arm64 never pays QEMU's interpreted-compile cost).
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS build
+ARG VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ENV CGO_ENABLED=0
+WORKDIR /build
+# Resolve VERSION to the module's version string so the stamped binary reports a
+# real release (the FleetNode heartbeats main.Version; an empty stamp shows as
+# "dev" in `kubectl get fleetnodes`). go list -m needs a module context.
+RUN mkdir -p /out /tmp/vresolve \
+    && ( cd /tmp/vresolve && go mod init coderbuild >/dev/null 2>&1 \
+         && go list -m -f '{{.Version}}' "github.com/defilantech/llmkube@v${VERSION}" > /out/llmkube.version ) \
+    && LLMKUBE_VERSION="$(cat /out/llmkube.version)" \
+    && GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" go install -trimpath \
+         -ldflags="-s -w -X main.Version=${LLMKUBE_VERSION} -X main.GitCommit=v${VERSION}" \
+         "github.com/defilantech/llmkube/cmd/foreman-agent@v${VERSION}" \
+    && cp "$(find "$(go env GOPATH)/bin" -name foreman-agent -type f | head -1)" /out/foreman-agent \
+    && test -x /out/foreman-agent
+
+# Runtime: Node 22 (the language this fleet's coder self-gate targets) + git +
+# the linters the gate runs. No Go: the target repos are Node and the agent
+# binary is static.
+FROM node:22-bookworm-slim@sha256:813a7480f28fdadac1f7f5c824bcdad435b5bc1322a5968bbbdef8d058f9dff4
+
+LABEL org.opencontainers.image.title="llmkube-coder-node" \
+      org.opencontainers.image.description="LLMKube foreman coder agent (built from source) with a Node self-gate toolchain" \
+      org.opencontainers.image.source="https://github.com/defilantech/LLMKube" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# git for the coder workspace.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Node self-gate linters.
+# renovate: datasource=npm depName=eslint
+ARG ESLINT_VERSION=10.6.0
+# renovate: datasource=npm depName=prisma
+ARG PRISMA_VERSION=7.8.0
+# renovate: datasource=npm depName=typescript
+ARG TYPESCRIPT_VERSION=6.0.3
+RUN npm install -g --no-fund --no-audit \
+      "eslint@${ESLINT_VERSION}" "prisma@${PRISMA_VERSION}" "typescript@${TYPESCRIPT_VERSION}" \
+    && rm -rf /root/.npm
+
+# Read-only-rootfs friendly: all writable state under /tmp, and git operates on
+# the workspace regardless of the (possibly pod-overridden) uid.
+ENV HOME=/tmp \
+    npm_config_cache=/tmp/.npm
+RUN git config --system --add safe.directory '*'
+
+COPY --from=build /out/foreman-agent /foreman-agent
+RUN chmod 0755 /foreman-agent \
+    && ln -sf /foreman-agent /usr/local/bin/foreman-agent
+
+# nobody:nogroup (repo default). The foreman pod may override the uid; the image
+# is uid-agnostic — all writable state lives in /tmp and the tools are
+# world-executable.
+USER 65534:65534
+ENTRYPOINT ["/foreman-agent"]

--- a/apps/llmkube-coder-node/container_test.go
+++ b/apps/llmkube-coder-node/container_test.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/llmkube-coder-node:rolling")
+	testhelpers.TestFileExists(t, image, "/foreman-agent", nil)
+	// The agent binary and the Node toolchain the coder self-gate uses.
+	testhelpers.TestCommandSucceeds(t, image, nil, "foreman-agent", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "node", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "npm", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "git", "--version")
+	// Representative Node linter.
+	testhelpers.TestCommandSucceeds(t, image, nil, "eslint", "--version")
+}

--- a/apps/llmkube-coder-node/docker-bake.hcl
+++ b/apps/llmkube-coder-node/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "llmkube-coder-node"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=defilantech/LLMKube
+  default = "0.9.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/defilantech/LLMKube"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}

--- a/apps/llmkube-coder-python/Dockerfile
+++ b/apps/llmkube-coder-python/Dockerfile
@@ -1,0 +1,68 @@
+# syntax=docker/dockerfile:1
+
+# Build stage: cross-compile the static foreman-agent from LLMKube source.
+# CGO is disabled, so the binary runs on the Python runtime below with no
+# Go toolchain present. Pinned to $BUILDPLATFORM + GOOS/GOARCH so the compiler
+# always runs natively (arm64 never pays QEMU's interpreted-compile cost).
+FROM --platform=$BUILDPLATFORM golang:1.26-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS build
+ARG VERSION
+ARG TARGETOS
+ARG TARGETARCH
+ENV CGO_ENABLED=0
+WORKDIR /build
+# Resolve VERSION to the module's version string so the stamped binary reports a
+# real release (the FleetNode heartbeats main.Version; an empty stamp shows as
+# "dev" in `kubectl get fleetnodes`). go list -m needs a module context.
+RUN mkdir -p /out /tmp/vresolve \
+    && ( cd /tmp/vresolve && go mod init coderbuild >/dev/null 2>&1 \
+         && go list -m -f '{{.Version}}' "github.com/defilantech/llmkube@v${VERSION}" > /out/llmkube.version ) \
+    && LLMKUBE_VERSION="$(cat /out/llmkube.version)" \
+    && GOOS="${TARGETOS:-linux}" GOARCH="${TARGETARCH}" go install -trimpath \
+         -ldflags="-s -w -X main.Version=${LLMKUBE_VERSION} -X main.GitCommit=v${VERSION}" \
+         "github.com/defilantech/llmkube/cmd/foreman-agent@v${VERSION}" \
+    && cp "$(find "$(go env GOPATH)/bin" -name foreman-agent -type f | head -1)" /out/foreman-agent \
+    && test -x /out/foreman-agent
+
+# Runtime: Python 3.14 (the language this fleet's coder self-gate targets) +
+# git + the linters the gate runs. No Go: the target repos are Python and the
+# agent binary is static.
+FROM python:3.14-slim-bookworm@sha256:4ff4b92a68355dbdb52584ab3391dff8d371a61d4e063468bfd0130e3189c6d9
+
+LABEL org.opencontainers.image.title="llmkube-coder-python" \
+      org.opencontainers.image.description="LLMKube foreman coder agent (built from source) with a Python self-gate toolchain" \
+      org.opencontainers.image.source="https://github.com/defilantech/LLMKube" \
+      org.opencontainers.image.licenses="Apache-2.0"
+
+# git for the coder workspace.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python self-gate linters.
+# renovate: datasource=pypi depName=ruff
+ARG RUFF_VERSION=0.15.20
+# renovate: datasource=pypi depName=black
+ARG BLACK_VERSION=26.5.1
+# renovate: datasource=pypi depName=flake8
+ARG FLAKE8_VERSION=7.3.0
+# renovate: datasource=pypi depName=yamllint
+ARG YAMLLINT_VERSION=1.38.0
+RUN pip install --no-cache-dir \
+      "ruff==${RUFF_VERSION}" "black==${BLACK_VERSION}" \
+      "flake8==${FLAKE8_VERSION}" "yamllint==${YAMLLINT_VERSION}"
+
+# Read-only-rootfs friendly: all writable state under /tmp, and git operates on
+# the workspace regardless of the (possibly pod-overridden) uid.
+ENV HOME=/tmp \
+    PIP_CACHE_DIR=/tmp/.pip
+RUN git config --system --add safe.directory '*'
+
+COPY --from=build /out/foreman-agent /foreman-agent
+RUN chmod 0755 /foreman-agent \
+    && ln -sf /foreman-agent /usr/local/bin/foreman-agent
+
+# nobody:nogroup (repo default). The foreman pod may override the uid; the image
+# is uid-agnostic — all writable state lives in /tmp and the tools are
+# world-executable.
+USER 65534:65534
+ENTRYPOINT ["/foreman-agent"]

--- a/apps/llmkube-coder-python/container_test.go
+++ b/apps/llmkube-coder-python/container_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/llmkube-coder-python:rolling")
+	testhelpers.TestFileExists(t, image, "/foreman-agent", nil)
+	// The agent binary and the Python toolchain the coder self-gate uses.
+	testhelpers.TestCommandSucceeds(t, image, nil, "foreman-agent", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "python3", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "git", "--version")
+	// Representative Python linter.
+	testhelpers.TestCommandSucceeds(t, image, nil, "ruff", "--version")
+}

--- a/apps/llmkube-coder-python/docker-bake.hcl
+++ b/apps/llmkube-coder-python/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "llmkube-coder-python"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=defilantech/LLMKube
+  default = "0.9.0"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/defilantech/LLMKube"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
## Summary
- Split the polyglot `llmkube-coder` toolchain into two minimal single-language images for the foreman per-language coder Agents (running in Job mode):
  - `llmkube-coder-python` — `python:3.14-slim` + git + ruff/black/flake8/yamllint
  - `llmkube-coder-node` — `node:22-slim` + git + eslint/prisma/typescript
- Each keeps the source-built `foreman-agent` binary (same Go build stage) and drops the other language's runtime + linters.
- The existing polyglot `llmkube-coder` image is untouched — it stays as the InProcess fleet image for the escalation/revision tiers and the generic fallback coder.

## Verification
- `docker buildx bake image-local --print` valid for both.
- `gofmt` clean; per-language `container_test.go` asserts the right toolchain (python: no node/npm/eslint; node: no python/ruff).
- Full image build runs in CI.

## Notes
- Consumed by the `coder-python`/`coder-node` Agents in home-ops (separate PR). `VERSION` is Renovate-tracked against LLMKube releases, same as the polyglot image.