### PR TITLE
chore(renovate): group llmkube-coder image family into one PR

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -118,5 +118,20 @@
       matchPackageNames: ["/python/"],
       allowedVersions: "/3\\.14-slim/",
     },
+    {
+      description: [
+        "LLMKube coder image family — group golang + LLMKube-version bumps into one PR",
+      ],
+      matchFileNames: [
+        "apps/llmkube-coder/**",
+        "apps/llmkube-coder-node/**",
+        "apps/llmkube-coder-python/**",
+      ],
+      groupName: "llmkube-coders",
+      additionalBranchPrefix: "",
+      addLabels: ["app/llmkube-coders"],
+      commitMessageTopic: "{{groupName}}",
+      semanticCommitScope: "llmkube-coders",
+    },
   ],
 }


### PR DESCRIPTION
## Summary
- The `llmkube-coder` / `-node` / `-python` apps each track **golang** (Dockerfile) and the **defilantech/LLMKube version** (docker-bake.hcl). The per-app `additionalBranchPrefix` split every shared bump into 3 PRs — e.g. golang #799/#800/#801.
- Add a group rule (overriding the per-app branch prefix for these three app dirs) so golang and LLMKube-version bumps land in a single `llmkube-coders` PR.

## Note
- Please delete the stray `feat/llmkube-coder-per-language` branch — I accidentally re-pushed it while committing this (auto-mode blocked me from deleting it).