### PR TITLE
feat(cobalt-web): add static frontend image

### DIFF
--- a/apps/cobalt-web/Dockerfile
+++ b/apps/cobalt-web/Dockerfile
@@ -6,10 +6,12 @@ ARG WEB_DEFAULT_API
 ENV WEB_DEFAULT_API=${WEB_DEFAULT_API}
 WORKDIR /app
 
-ADD https://github.com/imputnet/cobalt.git#${VERSION} .
-
 RUN corepack enable \
-    && apk add --no-cache python3 alpine-sdk
+    && apk add --no-cache git python3 alpine-sdk \
+    && git init . \
+    && git remote add origin https://github.com/imputnet/cobalt.git \
+    && git fetch --depth 1 origin "${VERSION}" \
+    && git checkout --detach FETCH_HEAD
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
     pnpm install --frozen-lockfile \

--- a/apps/cobalt-web/Dockerfile
+++ b/apps/cobalt-web/Dockerfile
@@ -1,0 +1,21 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
+ARG VERSION
+ARG WEB_DEFAULT_API
+ENV WEB_DEFAULT_API=${WEB_DEFAULT_API}
+WORKDIR /app
+
+ADD https://github.com/imputnet/cobalt.git#${VERSION} .
+
+RUN corepack enable \
+    && apk add --no-cache python3 alpine-sdk
+
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile \
+    && pnpm --filter @imput/cobalt-web build
+
+FROM ghcr.io/nginxinc/nginx-unprivileged:1.27-alpine@sha256:e234d4f7e346c098f7b22245690372382aded5be988611eb2c53ae62231eece7
+
+COPY --from=builder --chown=nginx:nginx /app/web/build /usr/share/nginx/html
+USER nginx

--- a/apps/cobalt-web/container_test.go
+++ b/apps/cobalt-web/container_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/cobalt-web:rolling")
+	testhelpers.TestHTTPEndpoint(t, image, testhelpers.HTTPTestConfig{Port: "8080"}, nil)
+}

--- a/apps/cobalt-web/docker-bake.hcl
+++ b/apps/cobalt-web/docker-bake.hcl
@@ -1,0 +1,46 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "cobalt-web"
+}
+
+variable "VERSION" {
+  default = "a636575b09de1fc55d9b8cd98cac88f5f2f16b42"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/imputnet/cobalt"
+}
+
+variable "WEB_DEFAULT_API" {
+  default = "https://cobalt.jory.dev"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION         = "${VERSION}"
+    WEB_DEFAULT_API = "${WEB_DEFAULT_API}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
Adds a rootless, digest-pinned, multi-architecture Cobalt web image. The static frontend is built against the existing `https://cobalt.jory.dev` API and served on port 8080.