### PR TITLE
fix(cobalt-web): separate source and release versions

### DIFF
--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -83,11 +83,6 @@
       ignoreTests: false,
     },
     {
-      description: ["Group Cobalt Updates"],
-      matchFileNames: ["apps/cobalt-web/docker-bake.hcl"],
-      groupName: "cobalt",
-    },
-    {
       description: ["Allowed Ubuntu Version for Base Images"],
       matchDatasources: ["docker"],
       matchPackageNames: ["/ubuntu/"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -25,6 +25,17 @@
       datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
     },
+    {
+      customType: "regex",
+      description: "Process Git Refs in Docker Bake",
+      managerFilePatterns: ["/(^|/)docker-bake\\.hcl$/"],
+      matchStrings: [
+        'git-ref depName=(?<depName>\\S+)\\nvariable "\\S+" \\{\\n  default = "(?<currentDigest>[^"]+)"',
+      ],
+      datasourceTemplate: "git-refs",
+      packageNameTemplate: "https://github.com/{{depName}}",
+      currentValueTemplate: "main",
+    },
   ],
   customDatasources: {
     qbittorrent: {
@@ -70,6 +81,11 @@
       automerge: true,
       automergeType: "pr",
       ignoreTests: false,
+    },
+    {
+      description: ["Group Cobalt Updates"],
+      matchFileNames: ["apps/cobalt-web/docker-bake.hcl"],
+      groupName: "cobalt",
     },
     {
       description: ["Allowed Ubuntu Version for Base Images"],

--- a/.renovaterc.json5
+++ b/.renovaterc.json5
@@ -83,6 +83,11 @@
       ignoreTests: false,
     },
     {
+      description: ["Group Cobalt Updates"],
+      matchDepNames: ["ghcr.io/imputnet/cobalt", "imputnet/cobalt"],
+      groupName: "cobalt",
+    },
+    {
       description: ["Allowed Ubuntu Version for Base Images"],
       matchDatasources: ["docker"],
       matchPackageNames: ["/ubuntu/"],

--- a/apps/cobalt-web/Dockerfile
+++ b/apps/cobalt-web/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 FROM docker.io/library/node:24-alpine@sha256:a0b9bf06e4e6193cf7a0f58816cc935ff8c2a908f81e6f1a95432d679c54fbfd AS builder
-ARG VERSION
+ARG SOURCE_REF
 ARG WEB_DEFAULT_API
 ENV WEB_DEFAULT_API=${WEB_DEFAULT_API}
 WORKDIR /app
@@ -10,7 +10,7 @@ RUN corepack enable \
     && apk add --no-cache git python3 alpine-sdk \
     && git init . \
     && git remote add origin https://github.com/imputnet/cobalt.git \
-    && git fetch --depth 1 origin "${VERSION}" \
+    && git fetch --depth 1 origin "${SOURCE_REF}" \
     && git checkout --detach FETCH_HEAD
 
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \

--- a/apps/cobalt-web/docker-bake.hcl
+++ b/apps/cobalt-web/docker-bake.hcl
@@ -5,10 +5,12 @@ variable "APP" {
 }
 
 variable "VERSION" {
+  // renovate: datasource=docker depName=ghcr.io/imputnet/cobalt
   default = "11.7.1"
 }
 
 variable "SOURCE_REF" {
+  // renovate: git-ref depName=imputnet/cobalt
   default = "a636575b09de1fc55d9b8cd98cac88f5f2f16b42"
 }
 

--- a/apps/cobalt-web/docker-bake.hcl
+++ b/apps/cobalt-web/docker-bake.hcl
@@ -5,6 +5,10 @@ variable "APP" {
 }
 
 variable "VERSION" {
+  default = "11.7.1"
+}
+
+variable "SOURCE_REF" {
   default = "a636575b09de1fc55d9b8cd98cac88f5f2f16b42"
 }
 
@@ -23,7 +27,7 @@ group "default" {
 target "image" {
   inherits = ["docker-metadata-action"]
   args = {
-    VERSION         = "${VERSION}"
+    SOURCE_REF      = "${SOURCE_REF}"
     WEB_DEFAULT_API = "${WEB_DEFAULT_API}"
   }
   labels = {


### PR DESCRIPTION
Restores the public image version to Cobalt 11.7.1 and keeps the immutable Git commit in a separate `SOURCE_REF` build argument. This restores semver image tagging without losing reproducible source builds.