### PR TITLE
fix(rocm-smi-exporter): keep sensor label on power series, review polish

### DIFF
--- a/apps/rocm-smi-exporter/README.md
+++ b/apps/rocm-smi-exporter/README.md
@@ -37,12 +37,12 @@ AMDGPU device metrics when exposed by the kernel:
 - `rocm_smi_visible_vram_total_bytes`
 - `rocm_smi_gtt_used_bytes`
 - `rocm_smi_gtt_total_bytes`
-- `rocm_smi_pcie_replay_count`
+- `rocm_smi_pcie_replay_total (counter)`
 
 HWMON metrics when exposed by the kernel:
 
 - `rocm_smi_temperature_celsius{sensor=...}`
-- `rocm_smi_power_watts{type=...}`
+- `rocm_smi_power_watts{sensor=...,type=...}`
 - `rocm_smi_fan_rpm{sensor=...}`
 - `rocm_smi_clock_hertz{sensor=...}`
 - `rocm_smi_voltage_volts{sensor=...}`

--- a/apps/rocm-smi-exporter/main.go
+++ b/apps/rocm-smi-exporter/main.go
@@ -70,7 +70,11 @@ func main() {
 	})
 
 	log.Printf("listening on %s/metrics with SYSFS_ROOT=%s", cfg.listenAddr, cfg.sysfsRoot)
-	log.Fatal(http.ListenAndServe(cfg.listenAddr, nil))
+	server := &http.Server{
+		Addr:              cfg.listenAddr,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }
 
 func envDefault(name, fallback string) string {
@@ -117,7 +121,7 @@ func collect(cfg config) ([]metric, error) {
 		metrics = append(metrics, readSimpleGauge(dev, "mem_info_vis_vram_total", "visible_vram_total_bytes", "Total visible VRAM bytes.", 1)...)
 		metrics = append(metrics, readSimpleGauge(dev, "mem_info_gtt_used", "gtt_used_bytes", "Currently used GTT bytes.", 1)...)
 		metrics = append(metrics, readSimpleGauge(dev, "mem_info_gtt_total", "gtt_total_bytes", "Total GTT bytes.", 1)...)
-		metrics = append(metrics, readSimpleGauge(dev, "pcie_replay_count", "pcie_replay_count", "Total PCIe replay count reported by amdgpu.", 1)...)
+		metrics = append(metrics, readSimpleCounter(dev, "pcie_replay_count", "pcie_replay_total", "Total PCIe replay count reported by amdgpu.", 1)...)
 		metrics = append(metrics, collectHwmon(dev)...)
 	}
 
@@ -186,11 +190,19 @@ func cleanLabel(value string) string {
 }
 
 func readSimpleGauge(dev device, sysfsName, metricName, help string, divisor float64) []metric {
+	return readSimple(dev, sysfsName, metricName, help, divisor, "gauge")
+}
+
+func readSimpleCounter(dev device, sysfsName, metricName, help string, divisor float64) []metric {
+	return readSimple(dev, sysfsName, metricName, help, divisor, "counter")
+}
+
+func readSimple(dev device, sysfsName, metricName, help string, divisor float64, type_ string) []metric {
 	value, ok := readFloatFile(filepath.Join(dev.path, sysfsName), divisor)
 	if !ok {
 		return nil
 	}
-	return []metric{{name: metricName, help: help, type_: "gauge", labels: baseLabels(dev), value: value}}
+	return []metric{{name: metricName, help: help, type_: type_, labels: baseLabels(dev), value: value}}
 }
 
 func collectHwmon(dev device) []metric {
@@ -246,8 +258,10 @@ func hwmonMetric(dev device, hwmonDir, prefix, index, kind string) (string, stri
 	case "temp":
 		return "temperature_celsius", "AMDGPU temperature sensor value in celsius.", labels, 1000, true
 	case "power":
+		// Keep the sensor index label: a device exposing power1_average and
+		// power2_average must emit distinct series, or the duplicate label
+		// sets make the whole exposition invalid.
 		labels["type"] = kind
-		delete(labels, "sensor")
 		return "power_watts", "AMDGPU power sensor value in watts.", labels, 1000000, true
 	case "fan":
 		return "fan_rpm", "AMDGPU fan speed in RPM.", labels, 1, kind == "input"

--- a/apps/rocm-smi-exporter/main_test.go
+++ b/apps/rocm-smi-exporter/main_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -54,4 +56,178 @@ func assertMetricValue(t *testing.T, metrics []metric, name string, value float6
 		}
 	}
 	t.Fatalf("metric %s=%v not found in %#v", name, value, metrics)
+}
+
+// TestPowerSensorsStayDistinct is the regression for the review finding:
+// a device exposing two power sensors of the same kind must emit two
+// distinct series (sensor label retained), and the rendered exposition
+// must contain no duplicate label sets — which Prometheus would reject.
+func TestPowerSensorsStayDistinct(t *testing.T) {
+	root := t.TempDir()
+	devicePath := filepath.Join(root, "class", "drm", "card0", "device")
+	hwmonPath := filepath.Join(devicePath, "hwmon", "hwmon0")
+	if err := os.MkdirAll(hwmonPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, devicePath, "vendor", "0x1002\n")
+	writeFixture(t, hwmonPath, "power1_average", "120000000\n")
+	writeFixture(t, hwmonPath, "power2_average", "45000000\n")
+
+	metrics, err := collect(config{sysfsRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var powerSeries []metric
+	for _, m := range metrics {
+		if m.name == "power_watts" {
+			powerSeries = append(powerSeries, m)
+		}
+	}
+	if len(powerSeries) != 2 {
+		t.Fatalf("want 2 power_watts series, got %d: %#v", len(powerSeries), powerSeries)
+	}
+	if powerSeries[0].labels["sensor"] == powerSeries[1].labels["sensor"] {
+		t.Fatalf("power series must carry distinct sensor labels, both got %q", powerSeries[0].labels["sensor"])
+	}
+
+	assertNoDuplicateSeries(t, renderExposition(t, metrics))
+}
+
+// TestVendorFilterSkipsNonAMD: a non-AMD card (vendor 0x10de) must not
+// be discovered.
+func TestVendorFilterSkipsNonAMD(t *testing.T) {
+	root := t.TempDir()
+	amd := filepath.Join(root, "class", "drm", "card0", "device")
+	nvidia := filepath.Join(root, "class", "drm", "card1", "device")
+	for _, d := range []string{amd, nvidia} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeFixture(t, amd, "vendor", "0x1002\n")
+	writeFixture(t, nvidia, "vendor", "0x10de\n")
+
+	metrics, err := collect(config{sysfsRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetricValue(t, metrics, "gpus_discovered", 1)
+	for _, m := range metrics {
+		if m.labels["card"] == "card1" {
+			t.Fatalf("non-AMD card1 must not emit metrics, got %#v", m)
+		}
+	}
+}
+
+// TestMissingFilesSkipPerMetric: an absent sysfs attribute skips that
+// one metric; the rest of the device still reports.
+func TestMissingFilesSkipPerMetric(t *testing.T) {
+	root := t.TempDir()
+	devicePath := filepath.Join(root, "class", "drm", "card0", "device")
+	if err := os.MkdirAll(devicePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, devicePath, "vendor", "0x1002\n")
+	writeFixture(t, devicePath, "mem_info_vram_used", "42\n")
+	// no gpu_busy_percent, no hwmon
+
+	metrics, err := collect(config{sysfsRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetricValue(t, metrics, "vram_used_bytes", 42)
+	for _, m := range metrics {
+		if m.name == "gpu_busy_percent" {
+			t.Fatalf("missing attribute must skip the metric, got %#v", m)
+		}
+	}
+}
+
+// TestMultiGPU: two AMD cards report side by side with distinct card labels.
+func TestMultiGPU(t *testing.T) {
+	root := t.TempDir()
+	for _, card := range []string{"card0", "card1"} {
+		devicePath := filepath.Join(root, "class", "drm", card, "device")
+		if err := os.MkdirAll(devicePath, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		writeFixture(t, devicePath, "vendor", "0x1002\n")
+		writeFixture(t, devicePath, "gpu_busy_percent", "7\n")
+	}
+
+	metrics, err := collect(config{sysfsRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertMetricValue(t, metrics, "gpus_discovered", 2)
+	cards := map[string]bool{}
+	for _, m := range metrics {
+		if m.name == "gpu_busy_percent" {
+			cards[m.labels["card"]] = true
+		}
+	}
+	if !cards["card0"] || !cards["card1"] {
+		t.Fatalf("want gpu_busy_percent for both cards, got %v", cards)
+	}
+	assertNoDuplicateSeries(t, renderExposition(t, metrics))
+}
+
+// TestExpositionOutput pins the rendered text format: HELP/TYPE emitted
+// once per metric, pcie replay exposed as a counter named _total.
+func TestExpositionOutput(t *testing.T) {
+	root := t.TempDir()
+	devicePath := filepath.Join(root, "class", "drm", "card0", "device")
+	if err := os.MkdirAll(devicePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFixture(t, devicePath, "vendor", "0x1002\n")
+	writeFixture(t, devicePath, "pcie_replay_count", "5\n")
+
+	metrics, err := collect(config{sysfsRoot: root})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := renderExposition(t, metrics)
+
+	if !strings.Contains(body, "# TYPE rocm_smi_pcie_replay_total counter") {
+		t.Fatalf("pcie replay must be a counter named _total; got:\n%s", body)
+	}
+	if !strings.Contains(body, "rocm_smi_pcie_replay_total{") {
+		t.Fatalf("pcie replay sample line missing; got:\n%s", body)
+	}
+	if strings.Count(body, "# TYPE rocm_smi_gpu_info gauge") != 1 {
+		t.Fatalf("HELP/TYPE must be emitted exactly once per metric; got:\n%s", body)
+	}
+	assertNoDuplicateSeries(t, body)
+}
+
+// renderExposition runs writeMetrics through an httptest recorder and
+// returns the body, so tests assert on the real exposition text.
+func renderExposition(t *testing.T, metrics []metric) string {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	writeMetrics(rec, metrics)
+	return rec.Body.String()
+}
+
+// assertNoDuplicateSeries fails if two sample lines share the same
+// name+label-set, which makes the exposition invalid to Prometheus.
+func assertNoDuplicateSeries(t *testing.T, body string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, line := range strings.Split(body, "\n") {
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		idx := strings.LastIndex(line, " ")
+		if idx < 0 {
+			continue
+		}
+		series := line[:idx]
+		if seen[series] {
+			t.Fatalf("duplicate series %q in exposition:\n%s", series, body)
+		}
+		seen[series] = true
+	}
 }


### PR DESCRIPTION
## Summary
- Backfill of the upstream review fixes from defilantech/llmkube-runtimes#16 (the port was byte-identical, so this is a direct copy of the fixed `main.go`/`main_test.go`):
  - `power_watts` keeps the `sensor` index label — multi-sensor devices emit distinct series instead of an invalid exposition Prometheus rejects
  - `rocm_smi_pcie_replay_total` as a proper counter (was `_count` gauge)
  - `http.Server` with `ReadHeaderTimeout: 5s`
  - 5 new tests incl. a rendered-exposition no-duplicate-series regression
- README metric names updated.

## Verification
- `go test`: unit tests 6/6 pass locally; `Test` (container structure) needs Docker — CI covers it.
- `gofmt` + `go vet` clean.

## Notes
- `rocm_smi_pcie_replay_count` → `_total` is a **metric rename** — if any dashboard/alert queries the old name, it needs the same rename on rollout.