### PR TITLE
feat: add opencode container image

### DIFF
--- a/apps/opencode/Dockerfile
+++ b/apps/opencode/Dockerfile
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+
+FROM docker.io/library/alpine:3.24
+ARG VERSION
+ARG TARGETARCH
+
+ENV BUN_RUNTIME_TRANSPILER_CACHE_PATH=0 \
+    HOME=/home/opencode
+
+RUN \
+    apk add --no-cache \
+        bash \
+        ca-certificates \
+        curl \
+        fd \
+        git \
+        github-cli \
+        jq \
+        libgcc \
+        libstdc++ \
+        openssh-client \
+        ripgrep \
+        tzdata \
+        yq \
+    && \
+    case "${TARGETARCH}" in \
+        'amd64') ASSET='opencode-linux-x64-baseline-musl' ;; \
+        'arm64') ASSET='opencode-linux-arm64-musl' ;; \
+        *) echo "unsupported arch ${TARGETARCH}" && exit 1 ;; \
+    esac \
+    && curl -fsSL "https://github.com/sst/opencode/releases/download/${VERSION}/${ASSET}.tar.gz" \
+        | tar -xz -C /usr/local/bin \
+    && chmod +x /usr/local/bin/opencode \
+    && \
+    adduser -D -u 1000 -h "${HOME}" opencode \
+    && mkdir -p "${HOME}" \
+    && chown -R opencode:opencode "${HOME}" \
+    && rm -rf /tmp/*
+
+USER opencode
+WORKDIR /home/opencode
+RUN opencode --version
+
+ENTRYPOINT ["opencode"]

--- a/apps/opencode/Dockerfile
+++ b/apps/opencode/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM docker.io/library/alpine:3.24
+FROM docker.io/library/alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
 ARG VERSION
 ARG TARGETARCH
 

--- a/apps/opencode/container_test.go
+++ b/apps/opencode/container_test.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/joryirving/containers/testhelpers"
+)
+
+func Test(t *testing.T) {
+	image := testhelpers.GetTestImage("ghcr.io/joryirving/opencode:rolling")
+	testhelpers.TestCommandSucceeds(t, image, nil, "/usr/local/bin/opencode", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "/usr/bin/git", "--version")
+	testhelpers.TestCommandSucceeds(t, image, nil, "/usr/bin/gh", "--version")
+}

--- a/apps/opencode/docker-bake.hcl
+++ b/apps/opencode/docker-bake.hcl
@@ -1,0 +1,42 @@
+target "docker-metadata-action" {}
+
+variable "APP" {
+  default = "opencode"
+}
+
+variable "VERSION" {
+  // renovate: datasource=github-releases depName=sst/opencode
+  default = "v1.18.19"
+}
+
+variable "SOURCE" {
+  default = "https://github.com/sst/opencode"
+}
+
+group "default" {
+  targets = ["image-local"]
+}
+
+target "image" {
+  inherits = ["docker-metadata-action"]
+  args = {
+    VERSION = "${VERSION}"
+  }
+  labels = {
+    "org.opencontainers.image.source" = "${SOURCE}"
+  }
+}
+
+target "image-local" {
+  inherits = ["image"]
+  output = ["type=docker"]
+  tags = ["${APP}:${VERSION}"]
+}
+
+target "image-all" {
+  inherits = ["image"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
For the in-cluster opencode server (home-ops side coming separately).

Alpine 3.24 plus the official `sst/opencode` musl release tarball — baseline on amd64, since a JS runtime doesn't care and it drops the AVX2 requirement. On top of that: git, gh, bash, jq, yq, fd, ripgrep, openssh-client, so a session can clone, branch, push and `gh pr create` instead of routing every edit through the GitHub MCP server.

There is a third-party image (`ghcr.io/anomalyco/opencode`) that would have worked, but it ships only `opencode` + `rg` — no git — and building from the upstream release keeps the supply chain to sst plus Alpine.

Verified locally on linux/amd64: all the binaries resolve, `opencode models` pulls the provider SDK at runtime, and `opencode run` against litellm returned a real completion.