### PR TITLE
Fix possible fix(deps): github.com/moby/go-archive v0.2.0 → 0.3.0 (CVE-2026-17106) in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/lufia/plan9stats v0.0.0-20260330125221-c963978e514e // indirect
 	github.com/magiconair/properties v1.8.10 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/go-archive v0.3.0 // indirect
 	github.com/moby/moby/api v1.55.0 // indirect
 	github.com/moby/moby/client v0.5.1
 	github.com/moby/patternmatcher v0.6.1 // indirect


### PR DESCRIPTION
Small change to `go.mod` — a scan flagged the code below and it looked genuine. It is around line 1.

The affected version of **github.com/moby/go-archive** extracts tar archives without properly confining the target paths. An attacker-controlled archive can include path‑traversal entries or malicious symlinks that cause the extractor to write or overwrite files outside the intended destination directory. This enables arbitrary file creation/modification on the host with the privileges of the extracting process, leading to potential privilege escalation or system compromise. The vulnerability is classified as **HIGH** severity.

Upgrade github.com/moby/go-archive from v0.2.0 to v0.3.0 to address CVE-2026-17106, which only requires updating the version line in go.mod.

For reference: rule `CVE-2026-17106`. Rated high.

I may well be missing context here — if the current code is deliberate, feel free to close this.

---
*Found with automated scanning ([RedGem](https://code.redgem.net)) and reviewed before opening. If it is not useful, closing it is completely fine.*
